### PR TITLE
[Feature/extensions] Adding extensibility support for extension point getNamedXContents

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -74,7 +74,8 @@ public class ExtensionsRunner {
     private final Logger logger = LogManager.getLogger(ExtensionsRunner.class);
     private final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
     };
-    private NamedWriteableRegistryAPI namedWriteableRegistryApi = new NamedWriteableRegistryAPI();
+    private NamedWriteableRegistryAPI namedWriteableRegistryAPI = new NamedWriteableRegistryAPI();
+    private NamedXContentRegistryAPI namedXContentRegistryAPI = new NamedXContentRegistryAPI();
 
     /**
      * Instantiates a new Extensions Runner.
@@ -123,7 +124,9 @@ public class ExtensionsRunner {
         // Read enum
         switch (request.getRequestType()) {
             case REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY:
-                return namedWriteableRegistryApi.handleNamedWriteableRegistryRequest(request);
+                return namedWriteableRegistryAPI.handleNamedWriteableRegistryRequest(request);
+            case REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY:
+                return namedXContentRegistryAPI.handleNamedXContentRegistryRequest(request);
             // Add additional request handlers here
             default:
                 throw new Exception("Handler not present for the provided request");
@@ -261,12 +264,21 @@ public class ExtensionsRunner {
         );
 
         transportService.registerRequestHandler(
+            ExtensionsOrchestrator.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY,
+            ThreadPool.Names.GENERIC,
+            false,
+            false,
+            OpenSearchRequest::new,
+            (request, channel, task) -> channel.sendResponse(handleOpenSearchRequest(request))
+        );
+
+        transportService.registerRequestHandler(
             ExtensionsOrchestrator.REQUEST_OPENSEARCH_PARSE_NAMED_WRITEABLE,
             ThreadPool.Names.GENERIC,
             false,
             false,
             NamedWriteableRegistryParseRequest::new,
-            (request, channel, task) -> channel.sendResponse(namedWriteableRegistryApi.handleNamedWriteableRegistryParseRequest(request))
+            (request, channel, task) -> channel.sendResponse(namedWriteableRegistryAPI.handleNamedWriteableRegistryParseRequest(request))
         );
 
         transportService.registerRequestHandler(

--- a/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
+++ b/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.ParseField;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.NamedXContentRegistryParseRequest;
+import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
+import org.opensearch.extensions.ExtensionBooleanResponse;
+import org.opensearch.extensions.OpenSearchRequest;
+
+/**
+ * API used to handle named xcontent registry requests from OpenSearch
+ */
+public class NamedXContentRegistryAPI {
+    private final Logger logger = LogManager.getLogger(NamedXContentRegistryAPI.class);
+    private List<NamedXContentRegistry.Entry> namedXContent;
+    private final NamedXContentRegistry namedXContentRegistry;
+
+    /**
+     * Constructor for NamedXContentRegistryAPI. Creates a NamedXContentRegistry for this extension
+     */
+    public NamedXContentRegistryAPI() {
+        this.namedXContent = getNamedXContents();
+        this.namedXContentRegistry = new NamedXContentRegistry(namedXContent);
+    }
+
+    /**
+     * Constructor for NamedXContentRegistryAPI. Creates and populates a NamedXContentRegistry with the given NamedWriteableRegistry entries for this extension
+     *
+     * @param extensionNamedXContent List of NamedXContentRegistry.Entry to be registered
+     */
+    public NamedXContentRegistryAPI(List<NamedXContentRegistry.Entry> extensionNamedXContent) {
+        this.namedXContent = extensionNamedXContent;
+        this.namedXContentRegistry = new NamedXContentRegistry(namedXContent);
+    }
+
+    /**
+     * Getter for NamedXContentRegistry
+     *
+     * @return The NamedXContentRegistry of this API
+     */
+    public NamedXContentRegistry getRegistry() {
+        return this.namedXContentRegistry;
+    }
+
+    /**
+     * Current placeholder for extension point override getNamedXContent(), will invoke extension point override here
+     *
+     * @return A list of NamedXContentRegistry entries that the extension wants to register within OpenSearch
+     */
+    private List<NamedXContentRegistry.Entry> getNamedXContents() {
+        List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>();
+        return namedXContents;
+    }
+
+    /**
+     * Handles a request from OpenSearch for named xcontent registry entries.
+     *
+     * @param request  The OpenSearch request to handle.
+     * @return A response with a list of xcontent ParseFields and fully qualified category class names to register within OpenSearch
+     */
+    public NamedXContentRegistryResponse handleNamedXContentRegistryRequest(OpenSearchRequest request) {
+        logger.info("Registering Named XContent Registry Request recieved from OpenSearch.");
+        // Iterate through Extensions's named xcontent and add to extension entries
+        Map<ParseField, Class> extensionEntries = new HashMap<>();
+        for (NamedXContentRegistry.Entry entry : this.namedXContent) {
+            extensionEntries.put(entry.name, entry.categoryClass);
+        }
+        NamedXContentRegistryResponse namedXContentRegistryResponse = new NamedXContentRegistryResponse(extensionEntries);
+        return namedXContentRegistryResponse;
+    }
+
+    public ExtensionBooleanResponse handleNamedXContentRegistryParseRequest(NamedXContentRegistryParseRequest request) throws IOException {
+        logger.info("Registering Named Writeable Registry Parse request from OpenSearch");
+        boolean status = false;
+
+        Class cateogoryClass = request.getCategoryClass();
+        String context = request.getContext();
+
+        // TODO : invoke parse on context
+
+        ExtensionBooleanResponse namedXContentRegistryParseResponse = new ExtensionBooleanResponse(status);
+        return namedXContentRegistryParseResponse;
+    }
+
+}

--- a/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
+++ b/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
@@ -16,9 +16,12 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.ParseField;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.NamedXContentRegistryParseRequest;
 import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.ExtensionBooleanResponse;
 import org.opensearch.extensions.OpenSearchRequest;
 
@@ -85,22 +88,24 @@ public class NamedXContentRegistryAPI {
     }
 
     /**
-     * Handles a request from OpenSearch to parse a named xcontent
+     * Handles a request from OpenSearch to generate a XContentParser with the given context
      *
      * @param request  The request to handle.
-     * @throws IOException if InputStream generated from the byte array is unsuccessfully closed
      * @return A response acknowledging the request to parse has executed successfully
      */
     public ExtensionBooleanResponse handleNamedXContentRegistryParseRequest(NamedXContentRegistryParseRequest request) throws IOException {
-        logger.info("Registering Named Writeable Registry Parse request from OpenSearch");
-        boolean status = false;
+        logger.info("Registering Named XContent Registry Parse request from OpenSearch");
 
-        Class cateogoryClass = request.getCategoryClass();
+        // Category class is required to invoke parser.namedObject() to generate the corresponding object within the xcontent registry
+        Class categoryClass = request.getCategoryClass();
         String context = request.getContext();
 
-        // TODO : invoke parse on context
+        // TODO : Currently providing extensions with the capability to generate XContentParsers via a request from OpenSearch. Determine
+        // how extensions utilize this XContentParser for updating an Anomaly Detector
+        XContentParser parser = XContentType.JSON.xContent()
+            .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, context);
 
-        ExtensionBooleanResponse namedXContentRegistryParseResponse = new ExtensionBooleanResponse(status);
+        ExtensionBooleanResponse namedXContentRegistryParseResponse = new ExtensionBooleanResponse(true);
         return namedXContentRegistryParseResponse;
     }
 

--- a/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
+++ b/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
@@ -84,6 +84,13 @@ public class NamedXContentRegistryAPI {
         return namedXContentRegistryResponse;
     }
 
+    /**
+     * Handles a request from OpenSearch to parse a named xcontent
+     *
+     * @param request  The request to handle.
+     * @throws IOException if InputStream generated from the byte array is unsuccessfully closed
+     * @return A response acknowledging the request to parse has executed successfully
+     */
     public ExtensionBooleanResponse handleNamedXContentRegistryParseRequest(NamedXContentRegistryParseRequest request) throws IOException {
         logger.info("Registering Named Writeable Registry Parse request from OpenSearch");
         boolean status = false;

--- a/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
+++ b/src/main/java/org/opensearch/sdk/NamedXContentRegistryAPI.java
@@ -39,7 +39,7 @@ public class NamedXContentRegistryAPI {
     }
 
     /**
-     * Constructor for NamedXContentRegistryAPI. Creates and populates a NamedXContentRegistry with the given NamedWriteableRegistry entries for this extension
+     * Constructor for NamedXContentRegistryAPI. Creates and populates a NamedXContentRegistry with the given entries for this extension
      *
      * @param extensionNamedXContent List of NamedXContentRegistry.Entry to be registered
      */

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -33,8 +33,6 @@ import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
-import org.opensearch.discovery.PluginRequest;
-import org.opensearch.discovery.PluginResponse;
 import org.opensearch.discovery.InitializeExtensionsRequest;
 import org.opensearch.discovery.InitializeExtensionsResponse;
 import org.opensearch.extensions.OpenSearchRequest;

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -94,7 +94,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     public void testRegisterRequestHandler() {
 
         extensionsRunner.startTransportService(transportService);
-        verify(transportService, times(5)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        verify(transportService, times(6)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -32,14 +32,11 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
-<<<<<<< HEAD
 import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
 import org.opensearch.discovery.PluginRequest;
 import org.opensearch.discovery.PluginResponse;
-=======
 import org.opensearch.discovery.InitializeExtensionsRequest;
 import org.opensearch.discovery.InitializeExtensionsResponse;
->>>>>>> main
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -32,6 +32,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
 import org.opensearch.discovery.PluginRequest;
 import org.opensearch.discovery.PluginResponse;
 import org.opensearch.extensions.OpenSearchRequest;
@@ -117,8 +118,21 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     @Test
     public void testHandleOpenSearchRequest() throws Exception {
 
-        OpenSearchRequest request = new OpenSearchRequest(OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY);
-        assertEquals(extensionsRunner.handleOpenSearchRequest(request).getClass(), NamedWriteableRegistryResponse.class);
+        OpenSearchRequest namedWriteableRegistryRequest = new OpenSearchRequest(
+            OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_WRITEABLE_REGISTRY
+        );
+        assertEquals(
+            NamedWriteableRegistryResponse.class,
+            extensionsRunner.handleOpenSearchRequest(namedWriteableRegistryRequest).getClass()
+        );
+
+        OpenSearchRequest namedXContentRegistryRequest = new OpenSearchRequest(
+            OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY
+        );
+        assertEquals(
+            NamedXContentRegistryResponse.class,
+            extensionsRunner.handleOpenSearchRequest(namedXContentRegistryRequest).getClass()
+        );
 
         // Add additional OpenSearch request handler tests here for each default extension point
     }

--- a/src/test/java/org/opensearch/sdk/TestNamedXContentRegistryAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestNamedXContentRegistryAPI.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.sdk;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.opensearch.common.ParseField;
+import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
+import org.opensearch.extensions.OpenSearchRequest;
+import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TestNamedXContentRegistryAPI extends OpenSearchTestCase {
+
+    private Object testObject;
+    private ParseField testParseField;
+    private List<NamedXContentRegistry.Entry> namedXContents;
+    private NamedXContentRegistryAPI namedXContentRegistryAPI;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.testObject = new Object();
+        this.testParseField = new ParseField("testObject");
+        this.namedXContents = Collections.singletonList(new NamedXContentRegistry.Entry(Object.class, testParseField, p -> testObject));
+        this.namedXContentRegistryAPI = new NamedXContentRegistryAPI(namedXContents);
+    }
+
+    @Test
+    public void testNamedXContentRegistryCreation() {
+        assert (namedXContentRegistryAPI.getRegistry() instanceof NamedXContentRegistry);
+    }
+
+    @Test
+    public void testNamedXContentRegistryRequest() throws UnknownHostException {
+        OpenSearchRequest request = new OpenSearchRequest(OpenSearchRequestType.REQUEST_OPENSEARCH_NAMED_XCONTENT_REGISTRY);
+        NamedXContentRegistryResponse response = namedXContentRegistryAPI.handleNamedXContentRegistryRequest(request);
+
+        assertEquals(1, response.getRegistry().size());
+        assertEquals(Object.class, response.getRegistry().get(testParseField));
+    }
+}

--- a/src/test/java/org/opensearch/sdk/TestNamedXContentRegistryAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestNamedXContentRegistryAPI.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.sdk;
 
+import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
@@ -19,7 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.opensearch.common.ParseField;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.NamedXContentRegistryParseRequest;
 import org.opensearch.common.xcontent.NamedXContentRegistryResponse;
+import org.opensearch.extensions.ExtensionBooleanResponse;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.test.OpenSearchTestCase;
@@ -51,5 +54,17 @@ public class TestNamedXContentRegistryAPI extends OpenSearchTestCase {
 
         assertEquals(1, response.getRegistry().size());
         assertEquals(Object.class, response.getRegistry().get(testParseField));
+    }
+
+    @Test
+    public void testNamedXContentParseRequest() throws UnknownHostException, IOException {
+
+        Class categoryClass = Object.class;
+        String context = "test context";
+        NamedXContentRegistryParseRequest request = new NamedXContentRegistryParseRequest(categoryClass, context);
+        ExtensionBooleanResponse response = namedXContentRegistryAPI.handleNamedXContentRegistryParseRequest(request);
+
+        // verify that XcontentParser creation was successful
+        assertEquals(response.getStatus(), true);
     }
 }


### PR DESCRIPTION
### Description
Adds support for registering named xcontent entries from extensions and transporting parse requests to extensions to generate XContent Parsers

### Issues Resolved
https://github.com/opensearch-project/opensearch/issues/3379

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
