### PR TITLE
Publish artifacts to maven local

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2,13 +2,14 @@
 # OpenSearch SDK Developer Guide
 - [Introduction](#introduction)
 - [Getting Started](#getting-started)
-	- [Git Clone OpenSearch-SDK Repo](#git-clone-OpenSearch-SDK-repo)
-	- [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
-	- [Publish OpenSearch Feature/Extensions branch to Maven local](#publish-opensearch-feature/extensions-branch-to-maven-local)
-	- [Run OpenSearch-SDK](#run-opensearch-sdk)
-	    - [Create extensions.yml file](#create_extensions_file)
+    - [Git Clone OpenSearch-SDK Repo](#git-clone-OpenSearch-SDK-repo)
+    - [Git Clone OpenSearch Repo](#git-clone-opensearch-repo)
+    - [Publish OpenSearch Feature/Extensions branch to Maven local](#publish-opensearch-featureextensions-branch-to-maven-local)
+    - [Run OpenSearch-SDK](#run-opensearch-sdk)
+        - [Create extensions.yml file](#create-extensionsyml-file)
         - [Run OpenSearch](#run-opensearch)
-	- [Run Tests](#run-tests)
+    - [Publish OpenSearch-SDK to Maven Local](#publish-openSearch-sdk-to-maven-local)
+    - [Run Tests](#run-tests)
     - [Submitting Changes](#submitting-changes)
 
 ## Introduction
@@ -54,7 +55,11 @@ Bound addresses will then be logged to the terminal :
 [main] INFO  transportservice.TransportService - profile [test]: publish_address {127.0.0.1:5555}, bound_addresses {[::1]:5555}, {127.0.0.1:5555}
 ```
 
-
+## Publish OpenSearch-SDK to Maven local
+Until we publish this repo to maven central. Publishing to maven local is the way to import the artifacts
+```
+./gradlew publishToMavenLocal
+```
 
 ## Create extensions.yml file
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,17 +31,13 @@ mainClassName = 'org.opensearch.sdk.ExtensionsRunner'
 group 'org.opensearch.sdk'
 version '1.0.0-SNAPSHOT'
 
-allprojects {
-    publishing {
-        publications {
-            group = "org.opensearch"
-            version = "1.0.0-SNAPSHOT"
-            mavenJava(MavenPublication) {
-                from components.java
-            }
-        }
-        repositories {
-            mavenLocal()
+
+publishing {
+    publications {
+        group = "org.opensearch"
+        version = "1.0.0-SNAPSHOT"
+        mavenJava(MavenPublication) {
+            from components.java
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,27 @@ ext {
 
 apply plugin: 'application'
 apply from: 'gradle/formatting.gradle'
+apply plugin: 'maven-publish'
 
 mainClassName = 'org.opensearch.sdk.ExtensionsRunner'
 
 group 'org.opensearch.sdk'
 version '1.0.0-SNAPSHOT'
+
+allprojects {
+    publishing {
+        publications {
+            group = "org.opensearch"
+            version = "1.0.0-SNAPSHOT"
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+        repositories {
+            mavenLocal()
+        }
+    }
+}
 
 repositories {
     mavenLocal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'opensearch-sdk'
+rootProject.name = 'opensearch-sdk-java'


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Publish artifacts to Maven and use SDK as a library. This will help us to just import the code from SDK rather than having the whole SDK package in AD extension.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-sdk-java/issues/98

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
