### PR TITLE
Register REST API and forward REST requests to associated extension

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,16 +32,19 @@ During the bootstrap of OpenSearch node, it class loads all the code under `~/pl
 
 ![](Docs/Extensions.png)
 
-Extensions are independent processes which are built using `opensearch-sdk`. They communicate with OpenSearch via [transport](https://github.com/opensearch-project/OpenSearch/tree/main/modules/transport-netty4) protocol which today is used to communicate between OpenSearch nodes.  
+Extensions are independent processes which are built using `opensearch-sdk`. They communicate with OpenSearch via [transport](https://github.com/opensearch-project/OpenSearch/tree/main/modules/transport-netty4) protocol which today is used to communicate between OpenSearch nodes. This follows a Request-Response pattern.
+
 Extensions are designed to extend features via transport APIs which are exposed using extension points of OpenSearch.
 
 ### Discovery
-Extensions are discovered and configured via `extensions.yml`, same way we currently have `plugin-descriptor.properties` which is read by OpenSearch during the node bootstrap. `ExtensionsOrchestrator` reads through the config file at `~/extensions` and registers extensions within OpenSearch.
+
+Extensions are discovered and configured via `extensions.yml`, the same way we currently have `plugin-descriptor.properties` which is read by OpenSearch during the node bootstrap. `ExtensionsOrchestrator` reads through the config file at `~/extensions` and registers extensions within OpenSearch.
+
 Here is an example extension configuration `extensions.yml`:
 
 ```
 extensions:
-  - name: opensearch-sdk // extension name
+  - name: sample-extension // extension name
     uniqueId: opensearch-sdk-1 // identifier for the extension
     hostName: 'sdk_host' // name of the host where extension is running
     hostAddress: '127.0.0.1' // host to reach
@@ -51,16 +54,41 @@ extensions:
     opensearchVersion: '3.0.0' // OpenSearch compatibility
 ```
 
-
 ### Communication
-As we are running extensions on the port defined in the `extensions.yml`, the communication between OpenSearch and Extensions happens using a ServerSocket which binds the port and the host address. OpenSearch will initialize the extensions during the bootstrap by making a request to all the extensions running on different ports and thus creating a medium for the future requests.
+
+Extensions will use a ServerSocket which binds them listen on a host address and port defined in their configuration file. Each type of incoming request will invoke code from an associated handler. 
+
+OpenSearch will have its own configuration file, presently `extensions.yml`, matching these addresses and ports. On startup, the ExtensionsOrchestrator will use the node's TransportService to communicate its requests to each extension, with the first request initializing the extension and validating the host and port.
+
+Immediately following initialization, each extension will establish a connection to OpenSearch on its own transport service, and send its REST API (a list of methods and URIs to which it will respond).  These will be registered with the RestController.
+
+When OpenSearch receives a registered method and URI, it will send the request to the Extension. The extension will appropriately handle the request, using the API to determine which Action to execute.
 
 ### OpenSearch SDK
-Currently, plugins relies on extension points to communicate with OpenSearch. To turn plugins into extensions, all the extension points should be converted into Transport APIs which will be present in the SDK. Plugins need to integrate SDK, call those APIs, and later SDK will take care of the communication and the required attributes from OpenSearch.
 
-### Settings
-Walking through a similar example as plugin above, after extension registration is done, extension makes an API call to register custom settings to OpenSearch.
-`ExtensionsOrchestrator` receives the requests, forwards it to `SettingsModule` to register a new setting and wala, the user is now able to toggle the setting via `_settings` Rest API.
+Currently, plugins rely on extension points to communicate with OpenSearch. These are represented as Actions. To turn plugins into extensions, the Extension must assemble a list of all methods and URIs to communicate to OpenSearch, where they will be registered; upon receiving a matching request from a user these will be forwarded back to the Extension and the Extension will further need to handle these registered methods and URIs with an appropriate Action.
+
+### Extension Walk Through
+
+1. Extensions are started up and must be running before OpenSearch is started.  (In the future, there will be a facility to refresh the extension list during operation and handle network communication interruptions.)
+
+2. OpenSearch is started. During its bootstrap, the `ExtensionsOrchestrator` is initialized, reading extension definitions from `extensions.yml`.
+
+3. The Node bootstrapping OpenSearch sends its transport service and REST controller objects to the `ExtensionsOrchestrator` which initializes a `RestActionsRequestHandler` object.  This completes the `ExtensionsOrchestrator` initialization.
+
+4. The `ExtensionsOrchestrator` iterates over its configured list of extensions, sending an initialization request to each one.
+
+5. Each Extension responds to the initialization request and then sends its REST API, a list of methods and URIs.
+
+6. The `RestActionsRequestHandler` registers these method/URI combinations in the `RestController` as the `routes()` that extension will handle.  This step relies on a globally unique combination of the Extension's `uniqueId` and the REST method and URI.  In theory multiple extensions may share the same `uniqueId` as long as their APIs do not overlap. Using reverse-DNS style names for the `uniqueId` is recommended for published extensions.
+
+At a later time:
+
+7. Users send REST requests to OpenSearch.
+
+8. If the requests match the registered `routes()` of an extension, the `RestRequest` is forwarded to the Extension, and the user receives an ACCEPTED (202) response. 
+
+9. Upon receipt of the `RestRequest`, the extension matches it to the appropriate Action and executes it.
 
 ## FAQ
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,21 +72,21 @@ Currently, plugins rely on extension points to communicate with OpenSearch. Thes
 
 1. Extensions are started up and must be running before OpenSearch is started.  (In the future, there will be a facility to refresh the extension list during operation and handle network communication interruptions.)
 
-2. OpenSearch is started. During its bootstrap, the `ExtensionsOrchestrator` is initialized, reading extension definitions from `extensions.yml`.
+2. OpenSearch is started. During its bootstrap, the `ExtensionsOrchestrator` is initialized, reading a list of extensions present in `extensions.yml`.
 
-3. The Node bootstrapping OpenSearch sends its transport service and REST controller objects to the `ExtensionsOrchestrator` which initializes a `RestActionsRequestHandler` object.  This completes the `ExtensionsOrchestrator` initialization.
+3. The Node bootstrapping OpenSearch sends its `RestController`, `TransportService`, and `ClusterService` objects to the `ExtensionsOrchestrator` which initializes a `RestActionsRequestHandler` object. This completes the `ExtensionsOrchestrator` initialization.
 
-4. The `ExtensionsOrchestrator` iterates over its configured list of extensions, sending an initialization request to each one.
+4. The `ExtensionsOrchestrator` iterates over its configured list of extensions, sending an initialization request to each one, tracking those that respond, and initializing the `ExtensionNamedWriteableRegistry`.
 
-5. Each Extension responds to the initialization request and then sends its REST API, a list of methods and URIs.
+5. After each Extension responds to the initialization request, it sends its REST API, a list of methods and URIs.
 
-6. The `RestActionsRequestHandler` registers these method/URI combinations in the `RestController` as the `routes()` that extension will handle.  This step relies on a globally unique combination of the Extension's `uniqueId` and the REST method and URI.  In theory multiple extensions may share the same `uniqueId` as long as their APIs do not overlap. Using reverse-DNS style names for the `uniqueId` is recommended for published extensions.
+6. The `RestActionsRequestHandler` registers these method/URI combinations in the `RestController` as the `routes()` that extension will handle.  This step relies on a globally unique identifier for the extension which users will use in REST requests, presently the Extension's `uniqueId`.
 
 At a later time:
 
 7. Users send REST requests to OpenSearch.
 
-8. If the requests match the registered `routes()` of an extension, the `RestRequest` is forwarded to the Extension, and the user receives an ACCEPTED (202) response. 
+8. If the requests match the registered path/URI and `routes()` of an extension, the `RestRequest` is forwarded to the Extension, and the user receives an ACCEPTED (202) response.
 
 9. Upon receipt of the `RestRequest`, the extension matches it to the appropriate Action and executes it.
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -371,11 +371,7 @@ public class ExtensionsRunner {
             transportService.sendRequest(
                 opensearchNode,
                 ExtensionsOrchestrator.REQUEST_EXTENSION_REGISTER_REST_ACTIONS,
-                new RegisterRestActionsRequest(
-                    extensionTransportService.getLocalNode().getId(),
-                    getUniqueId(),
-                    extensionRestPaths.getRestPaths()
-                ),
+                new RegisterRestActionsRequest(getUniqueId(), extensionRestPaths.getRestPaths()),
                 registerActionsResponseHandler
             );
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/sdk/handlers/RegisterRestActionsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/RegisterRestActionsResponseHandler.java
@@ -10,7 +10,7 @@ package org.opensearch.sdk.handlers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.extensions.RegisterRestActionsResponse;
+import org.opensearch.extensions.rest.RegisterRestActionsResponse;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;

--- a/src/main/java/org/opensearch/sdk/handlers/RegisterRestActionsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/RegisterRestActionsResponseHandler.java
@@ -27,7 +27,7 @@ public class RegisterRestActionsResponseHandler implements TransportResponseHand
 
     @Override
     public void handleResponse(RegisterRestActionsResponse response) {
-        logger.info("received {}", response);
+        logger.info("received {}", response.getResponse());
     }
 
     @Override

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -11,16 +11,16 @@
 
 package org.opensearch.sdk;
 
-import static java.util.Collections.emptySet;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -35,18 +35,21 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
-import org.opensearch.extensions.DiscoveryExtension;
 import org.opensearch.discovery.InitializeExtensionsRequest;
 import org.opensearch.discovery.InitializeExtensionsResponse;
-import org.opensearch.extensions.OpenSearchRequest;
+import org.opensearch.extensions.DiscoveryExtension;
 import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
+import org.opensearch.extensions.OpenSearchRequest;
+import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
+import org.opensearch.extensions.rest.RestExecuteOnExtensionResponse;
+import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.LocalNodeResponseHandler;
 import org.opensearch.sdk.handlers.RegisterRestActionsResponseHandler;
 import org.opensearch.test.OpenSearchTestCase;
-import org.opensearch.transport.TransportService;
 import org.opensearch.transport.Transport;
+import org.opensearch.transport.TransportService;
 
 public class TestExtensionsRunner extends OpenSearchTestCase {
 
@@ -95,7 +98,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     public void testRegisterRequestHandler() {
 
         extensionsRunner.startTransportService(transportService);
-        verify(transportService, times(5)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
+        verify(transportService, times(6)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -142,6 +145,15 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         assertEquals(NamedWriteableRegistryResponse.class, extensionsRunner.handleOpenSearchRequest(request).getClass());
 
         // Add additional OpenSearch request handler tests here for each default extension point
+    }
+
+    @Test
+    public void testHandleRestExecuteOnExtensionRequest() throws Exception {
+
+        RestExecuteOnExtensionRequest request = new RestExecuteOnExtensionRequest(Method.GET, "/foo");
+        RestExecuteOnExtensionResponse response = extensionsRunner.handleRestExecuteOnExtensionRequest(request);
+        assertTrue(response.getResponse().contains("GET"));
+        assertTrue(response.getResponse().contains("/foo"));
     }
 
     @Test


### PR DESCRIPTION
Companion PR: https://github.com/opensearch-project/OpenSearch/pull/4282

### Description

This and the companion PR linked above completes the work begun in #74 by registering the received API with the `RestController`.  When OpenSearch receives a `RestRequest` matching one of these registered routes, it forwards it to the appropriate extension for further action.

See the design schematic and description in #64
 - Steps 1 and 2 were already completed
 - [#4100](https://github.com/opensearch-project/OpenSearch/pull/4100) and #74 implemented step 3
 - This and the companion PR implement steps 4 through 8
 - Step 9 is outside the scope of this PR.

### Issues Resolved
Closes #64, Closes #69, and Closes #70

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
