### PR TITLE
Pass full RestResponse to user from Extension

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
@@ -14,6 +14,7 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestResponse;
 
 /**
  * This interface defines methods which an extension REST handler (action) must provide.
@@ -33,7 +34,7 @@ public interface ExtensionRestHandler {
      *
      * @param method A REST method.
      * @param uri The URI to handle.
-     * @return A response string to be sent to the end user via OpenSearch.
+     * @return A {@link RestResponse} to the request.
      */
-    String handleRequest(Method method, String uri);
+    RestResponse handleRequest(Method method, String uri);
 }

--- a/src/main/java/org/opensearch/sdk/sample/rest/RestHelloAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/rest/RestHelloAction.java
@@ -7,14 +7,18 @@
  */
 package org.opensearch.sdk.sample.rest;
 
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestResponse;
 import org.opensearch.sdk.ExtensionRestHandler;
 
 import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestStatus.OK;
+import static org.opensearch.rest.RestStatus.INTERNAL_SERVER_ERROR;
 
 /**
  * Sample REST Handler (REST Action). Extension REST handlers must implement {@link ExtensionRestHandler}.
@@ -29,11 +33,14 @@ public class RestHelloAction implements ExtensionRestHandler {
     }
 
     @Override
-    public String handleRequest(Method method, String uri) {
+    public RestResponse handleRequest(Method method, String uri) {
         if (Method.GET.equals(method) && "/hello".equals(uri)) {
-            return GREETING;
+            return new BytesRestResponse(OK, GREETING);
         }
-        return null;
+        return new BytesRestResponse(
+            INTERNAL_SERVER_ERROR,
+            "Extension REST action improperly configured to handle " + method.name() + " " + uri
+        );
     }
 
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -41,7 +42,9 @@ import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionResponse;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.LocalNodeResponseHandler;
@@ -149,8 +152,12 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         RestExecuteOnExtensionRequest request = new RestExecuteOnExtensionRequest(Method.GET, "/foo");
         RestExecuteOnExtensionResponse response = extensionsRunner.handleRestExecuteOnExtensionRequest(request);
-        assertTrue(response.getResponse().contains("GET"));
-        assertTrue(response.getResponse().contains("/foo"));
+        // this will fail in test environment with no registered actions
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.getStatus());
+        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.getContentType());
+        String responseStr = new String(response.getContent(), StandardCharsets.UTF_8);
+        assertTrue(responseStr.contains("GET"));
+        assertTrue(responseStr.contains("/foo"));
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/sample/rest/TestRestHelloAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/rest/TestRestHelloAction.java
@@ -7,12 +7,17 @@
  */
 package org.opensearch.sdk.sample.rest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestResponse;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -37,9 +42,23 @@ public class TestRestHelloAction extends OpenSearchTestCase {
 
     @Test
     public void testHandleRequest() {
-        assertEquals("Hello, World!", restHelloAction.handleRequest(Method.GET, "/hello"));
-        assertNull(restHelloAction.handleRequest(Method.PUT, "/hello"));
-        assertNull(restHelloAction.handleRequest(Method.GET, "/goodbye"));
+        RestResponse response = restHelloAction.handleRequest(Method.GET, "/hello");
+        assertEquals(RestStatus.OK, response.status());
+        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        String responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertEquals("Hello, World!", responseStr);
+
+        response = restHelloAction.handleRequest(Method.PUT, "/hello");
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertTrue(responseStr.contains("PUT"));
+
+        response = restHelloAction.handleRequest(Method.GET, "/goodbye");
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertTrue(responseStr.contains("/goodbye"));
     }
 
 }


### PR DESCRIPTION
Companion PR: https://github.com/opensearch-project/OpenSearch/pull/4356

### Description

In the initial SDK implementation, I simply returned a `String` from the Extension's REST handler to the user.  

This PR updates the (SDK API) return value to a `RestResponse` to match what a user would have received from OpenSearch itself or a plugin, including the HTTP Status Code, and the ability to return formats other than text.

As a bonus, I figured out how to test the input and output streams in the Request/Response classes and have improved those tests as well.

### Issues Resolved
Fixes #112 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
