### PR TITLE
Adding dbwiddis@ to opensearch-sdk-java as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@
 | Owais Kazi              | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Ryan Bogan              | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |
 | Sarat Vemulapalli       | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Dan Widdis              | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
 
 
 [This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
I nominated Dan Widdis (@dbwiddis ) to be a co-maintainer for opensearch-sdk-java through our [nomination process](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#nomination). The maintainers have agreed.
 
Dan is the author of [8 PRs ](https://github.com/opensearch-project/opensearch-sdk-java/pulls?q=is%3Apr+is%3Aclosed+author%3Adbwiddis) into OpenSearch, [third ](https://github.com/opensearch-project/opensearch-sdk-java/graphs/contributors)in code change volume after we created this new repo.

Dan is active almost daily in the project, thoughtfully reviewing and commenting on pull requests. Dan also focusses on improving the repo with the great ideas he got and also creating the right set of issues to get the ball rolling for Extensibility.
 
Some contributions from Dan:
1. https://github.com/opensearch-project/opensearch-sdk-java/pull/74
2. https://github.com/opensearch-project/opensearch-sdk-java/pull/51
3. https://github.com/opensearch-project/opensearch-sdk-java/pull/45
4. https://github.com/opensearch-project/opensearch-sdk-java/pull/109

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
