### PR TITLE
Remove warnings

### DIFF
--- a/src/main/java/org/opensearch/sdk/NamedWriteableRegistryAPI.java
+++ b/src/main/java/org/opensearch/sdk/NamedWriteableRegistryAPI.java
@@ -15,17 +15,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.opensearch.extensions.OpenSearchRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
-import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.io.stream.NamedWriteableRegistryParseRequest;
-import org.opensearch.extensions.ExtensionBooleanResponse;
 import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.extensions.ExtensionBooleanResponse;
+import org.opensearch.extensions.OpenSearchRequest;
 
 /**
  * API used to handle named writeable registry requests from OpenSearch
@@ -122,7 +121,7 @@ public class NamedWriteableRegistryAPI {
                 try {
 
                     // TODO : Determine how extensions utilize parsed object (https://github.com/opensearch-project/OpenSearch/issues/4067)
-                    NamedWriteable namedWriteable = streamInput.readNamedWriteable(categoryClass);
+                    streamInput.readNamedWriteable(categoryClass);
                     status = true;
                 } catch (UnsupportedOperationException e) {
                     logger.info("Failed to parse named writeable", e);

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -10,10 +10,7 @@ package org.opensearch.sdk;
 import java.io.IOException;
 
 import org.apache.http.HttpHost;
-
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
@@ -25,7 +22,6 @@ import org.opensearch.client.transport.rest_client.RestClientTransport;
  * This class creates SDKClient for an extension to make requests to OpenSearch
  */
 public class SDKClient {
-    private final Logger logger = LogManager.getLogger(SDKClient.class);
     private OpenSearchClient javaClient;
     private RestClient restClient = null;
 

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -35,7 +35,7 @@ public class TransportActions {
     public <Request extends ActionRequest, Response extends ActionResponse> TransportActions(
         Map<String, Class<? extends TransportAction<Request, Response>>> transportActions
     ) {
-        this.transportActions = new HashMap(transportActions);
+        this.transportActions = new HashMap<>(transportActions);
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
@@ -45,10 +45,6 @@ public class TestNamedWriteableRegistryAPI extends OpenSearchTestCase {
         public static final String NAME = "example";
         private final String message;
 
-        Example(String message) {
-            this.message = message;
-        }
-
         Example(StreamInput in) throws IOException {
             this.message = in.readString();
         }


### PR DESCRIPTION
Minor changes for warnings removal.

NamedWriteableRegistryAPI
  remove unused local variables
  remove unused imports

SDKClient
  remove unused private attribute
  remove unsed imports

TransportActions
  add missing diamond operators

TestNamedWriteableRegistryAPI
  remove unused constructor

There are still missing generic declaration on Class<> attributes and variables, which cannot be fixed only through sdk project, as they are used as method parameters from classes that do not belong to sdk project and would require changes on these classes as well.

Signed-off-by: Lucas Faria e Souza Vilela <luccasvilela@yahoo.com.br>

### Description
This change remove warnings from code without affecting any functionality.

### Issues Resolved
Fixes portions of #130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
