### PR TITLE
[Feature/Extensions] Adds Principal-Identity Token to extensions rest request

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
@@ -31,7 +31,7 @@ public interface ExtensionRestHandler {
      * This method corresponds to the {@link BaseRestHandler#prepareRequest} method.
      * As in that method, consumed parameters must be tracked and returned in the response.
      *
-     * @param restRequest a rest request object for a request to be forwarded to extensions
+     * @param restRequest a REST request object for a request to be forwarded to extensions
      * @return An {@link ExtensionRestResponse} to the request.
      */
     ExtensionRestResponse handleRequest(ExtensionRestRequest restRequest);

--- a/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
@@ -13,7 +13,6 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.rest.RestRequest.Method;
 
 /**
  * This interface defines methods which an extension REST handler (action) must provide.
@@ -32,9 +31,8 @@ public interface ExtensionRestHandler {
      * This method corresponds to the {@link BaseRestHandler#prepareRequest} method.
      * As in that method, consumed parameters must be tracked and returned in the response.
      *
-     * @param method A REST method.
-     * @param uri The URI to handle.
+     * @param restRequest a rest request object for a request to be forwarded to extensions
      * @return An {@link ExtensionRestResponse} to the request.
      */
-    ExtensionRestResponse handleRequest(Method method, String uri);
+    ExtensionRestResponse handleRequest(ExtensionRestRequest restRequest);
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
@@ -78,14 +78,23 @@ public class ExtensionRestRequest extends TransportRequest {
         out.writeNamedWriteable(principalIdentifierToken);
     }
 
+    /**
+     * @return This REST request {@link Method} type
+     */
     public Method method() {
         return method;
     }
 
+    /**
+     * @return This REST request's uri
+     */
     public String uri() {
         return uri;
     }
 
+    /**
+     * @return This REST request issuer's identity token
+     */
     public PrincipalIdentifierToken getRequestIssuerIdentity() {
         return principalIdentifierToken;
     }

--- a/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
@@ -17,25 +17,47 @@ import org.opensearch.transport.TransportRequest;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * A subclass of {@link TransportRequest} which contains request relevant information
+ * to be utilised in ExtensionRestHandler implementation
+ */
 public class ExtensionRestRequest extends TransportRequest {
-
     private Method method;
     private String uri;
+    /**
+     * The owner of this request object
+     */
     private PrincipalIdentifierToken principalIdentifierToken;
 
-    public ExtensionRestRequest(Method method, String uri, PrincipalIdentifierToken requesterIdentifier) {
+    /**
+     * This object can be instantiated given method, uri and identifier
+     * @param method of type {@link Method}
+     * @param uri url string
+     * @param principalIdentifier the owner of this request
+     */
+    public ExtensionRestRequest(Method method, String uri, PrincipalIdentifierToken principalIdentifier) {
         this.method = method;
         this.uri = uri;
-        this.principalIdentifierToken = requesterIdentifier;
+        this.principalIdentifierToken = principalIdentifier;
     }
 
-    // TODO Check if this constructor is more useful, If so what happens when request object is null
-    protected ExtensionRestRequest(RestExecuteOnExtensionRequest request) {
+    /**
+     * The object to be created from rest request object incoming from OpenSearch
+     * @param request incoming object from OpenSearch
+     * @throws IllegalArgumentException when request is null
+     */
+    protected ExtensionRestRequest(RestExecuteOnExtensionRequest request) throws IllegalArgumentException {
+        if (request == null) throw new IllegalArgumentException("Request object can't be null");
         this.method = request.getMethod();
         this.uri = request.getUri();
         this.principalIdentifierToken = request.getRequestIssuerIdentity();
     }
 
+    /**
+     * Object generated from input stream
+     * @param in Input stream
+     * @throws IOException
+     */
     public ExtensionRestRequest(StreamInput in) throws IOException {
         super(in);
         method = in.readEnum(Method.class);
@@ -43,6 +65,11 @@ public class ExtensionRestRequest extends TransportRequest {
         principalIdentifierToken = in.readNamedWriteable(PrincipalIdentifierToken.class);
     }
 
+    /**
+     * Write this object to output stream
+     * @param out the writeable output stream
+     * @throws IOException
+     */
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.sdk;
+
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
+import org.opensearch.identity.PrincipalIdentifierToken;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.transport.TransportRequest;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class ExtensionRestRequest extends TransportRequest {
+
+    private Method method;
+    private String uri;
+    private PrincipalIdentifierToken principalIdentifierToken;
+
+    public ExtensionRestRequest(Method method, String uri, PrincipalIdentifierToken requesterIdentifier) {
+        this.method = method;
+        this.uri = uri;
+        this.principalIdentifierToken = requesterIdentifier;
+    }
+
+    // TODO Check if this constructor is more useful, If so what happens when request object is null
+    protected ExtensionRestRequest(RestExecuteOnExtensionRequest request) {
+        this.method = request.getMethod();
+        this.uri = request.getUri();
+        this.principalIdentifierToken = request.getRequestIssuerIdentity();
+    }
+
+    public ExtensionRestRequest(StreamInput in) throws IOException {
+        super(in);
+        try {
+            method = RestRequest.Method.valueOf(in.readString());
+        } catch (IllegalArgumentException e) {
+            throw new IOException(e);
+        }
+        uri = in.readString();
+        principalIdentifierToken = in.readNamedWriteable(PrincipalIdentifierToken.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(method.name());
+        out.writeString(uri);
+        out.writeNamedWriteable(principalIdentifierToken);
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public PrincipalIdentifierToken getRequestIssuerIdentity() {
+        return principalIdentifierToken;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtensionRestRequest{method=" + method + ", uri=" + uri + ", requester = " + principalIdentifierToken.getToken() + "}";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        ExtensionRestRequest that = (ExtensionRestRequest) obj;
+        return Objects.equals(method, that.method)
+            && Objects.equals(uri, that.uri)
+            && Objects.equals(principalIdentifierToken, that.principalIdentifierToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, uri, principalIdentifierToken);
+    }
+}

--- a/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestRequest.java
@@ -11,7 +11,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
 import org.opensearch.identity.PrincipalIdentifierToken;
-import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.transport.TransportRequest;
 
@@ -39,11 +38,7 @@ public class ExtensionRestRequest extends TransportRequest {
 
     public ExtensionRestRequest(StreamInput in) throws IOException {
         super(in);
-        try {
-            method = RestRequest.Method.valueOf(in.readString());
-        } catch (IllegalArgumentException e) {
-            throw new IOException(e);
-        }
+        method = in.readEnum(Method.class);
         uri = in.readString();
         principalIdentifierToken = in.readNamedWriteable(PrincipalIdentifierToken.class);
     }
@@ -51,16 +46,16 @@ public class ExtensionRestRequest extends TransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(method.name());
+        out.writeEnum(method);
         out.writeString(uri);
         out.writeNamedWriteable(principalIdentifierToken);
     }
 
-    public Method getMethod() {
+    public Method method() {
         return method;
     }
 
-    public String getUri() {
+    public String uri() {
         return uri;
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -237,8 +237,15 @@ public class ExtensionsRunner {
                 "No handler for " + ExtensionRestPathRegistry.restPathToString(request.getMethod(), request.getUri())
             );
         }
+        // ExtensionRestRequest restRequest = new ExtensionRestRequest(request);
+        ExtensionRestRequest restRequest = new ExtensionRestRequest(
+            request.getMethod(),
+            request.getUri(),
+            request.getRequestIssuerIdentity()
+        );
+
         // Get response from extension
-        RestResponse response = restHandler.handleRequest(request.getMethod(), request.getUri());
+        RestResponse response = restHandler.handleRequest(restRequest);
         logger.info("Sending extension response to OpenSearch: " + response.status());
         return new RestExecuteOnExtensionResponse(
             response.status(),

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
@@ -43,8 +43,7 @@ public class RestHelloAction implements ExtensionRestHandler {
         List<String> consumedParams = new ArrayList<>();
         Method method = request.method();
         String uri = request.uri();
-        // TODO: should we extract token and then add it to the list of consumed parameters?
-        consumedParams.add(request.getRequestIssuerIdentity().getToken());
+
         if (Method.GET.equals(method) && "/hello".equals(uri)) {
             return new ExtensionRestResponse(OK, String.format(GREETING, worldName), consumedParams);
         } else if (Method.PUT.equals(method) && uri.startsWith("/hello/")) {

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
@@ -41,9 +41,10 @@ public class RestHelloAction implements ExtensionRestHandler {
     public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
         // We need to track which parameters are consumed to pass back to OpenSearch
         List<String> consumedParams = new ArrayList<>();
-        Method method = request.getMethod();
-        String uri = request.getUri();
-        // consumedParams.add(requesterIdentity.getToken());
+        Method method = request.method();
+        String uri = request.uri();
+        // TODO: should we extract token and then add it to the list of consumed parameters?
+        consumedParams.add(request.getRequestIssuerIdentity().getToken());
         if (Method.GET.equals(method) && "/hello".equals(uri)) {
             return new ExtensionRestResponse(OK, String.format(GREETING, worldName), consumedParams);
         } else if (Method.PUT.equals(method) && uri.startsWith("/hello/")) {

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
@@ -10,6 +10,7 @@ package org.opensearch.sdk.sample.helloworld.rest;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.sdk.ExtensionRestHandler;
+import org.opensearch.sdk.ExtensionRestRequest;
 import org.opensearch.sdk.ExtensionRestResponse;
 
 import java.net.URLDecoder;
@@ -37,9 +38,12 @@ public class RestHelloAction implements ExtensionRestHandler {
     }
 
     @Override
-    public ExtensionRestResponse handleRequest(Method method, String uri) {
+    public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
         // We need to track which parameters are consumed to pass back to OpenSearch
         List<String> consumedParams = new ArrayList<>();
+        Method method = request.getMethod();
+        String uri = request.getUri();
+        // consumedParams.add(requesterIdentity.getToken());
         if (Method.GET.equals(method) && "/hello".equals(uri)) {
             return new ExtensionRestResponse(OK, String.format(GREETING, worldName), consumedParams);
         } else if (Method.PUT.equals(method) && uri.startsWith("/hello/")) {

--- a/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
@@ -19,7 +19,7 @@ public class TestExtensionRestPathRegistry extends OpenSearchTestCase {
         }
 
         @Override
-        public ExtensionRestResponse handleRequest(Method method, String uri) {
+        public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
             return null;
         }
     };
@@ -30,7 +30,7 @@ public class TestExtensionRestPathRegistry extends OpenSearchTestCase {
         }
 
         @Override
-        public ExtensionRestResponse handleRequest(Method method, String uri) {
+        public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
             return null;
         }
     };
@@ -41,7 +41,7 @@ public class TestExtensionRestPathRegistry extends OpenSearchTestCase {
         }
 
         @Override
-        public ExtensionRestResponse handleRequest(Method method, String uri) {
+        public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
             return null;
         }
     };

--- a/src/test/java/org/opensearch/sdk/TestExtensionRestRequest.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionRestRequest.java
@@ -35,8 +35,8 @@ public class TestExtensionRestRequest extends OpenSearchTestCase {
 
         ExtensionRestRequest request = new ExtensionRestRequest(expectedMethod, expectedUri, expectedRequestIssuerIdentity);
 
-        assertEquals(expectedMethod, request.getMethod());
-        assertEquals(expectedUri, request.getUri());
+        assertEquals(expectedMethod, request.method());
+        assertEquals(expectedUri, request.uri());
         assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
 
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -47,8 +47,8 @@ public class TestExtensionRestRequest extends OpenSearchTestCase {
                     request = new ExtensionRestRequest(nameWritableAwareIn);
                 }
 
-                assertEquals(expectedMethod, request.getMethod());
-                assertEquals(expectedUri, request.getUri());
+                assertEquals(expectedMethod, request.method());
+                assertEquals(expectedUri, request.uri());
                 assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
             }
         }

--- a/src/test/java/org/opensearch/sdk/TestExtensionRestRequest.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionRestRequest.java
@@ -1,0 +1,57 @@
+package org.opensearch.sdk;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamInput;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.identity.ExtensionTokenProcessor;
+import org.opensearch.identity.PrincipalIdentifierToken;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.security.Principal;
+
+public class TestExtensionRestRequest extends OpenSearchTestCase {
+
+    @Test
+    public void testExtensionRestRequest() throws Exception {
+        RestRequest.Method expectedMethod = RestRequest.Method.GET;
+        String expectedUri = "/test/uri";
+        String extensionUniqueId1 = "ext_1";
+        Principal userPrincipal = () -> "user1";
+        ExtensionTokenProcessor extensionTokenProcessor = new ExtensionTokenProcessor(extensionUniqueId1);
+        PrincipalIdentifierToken expectedRequestIssuerIdentity = extensionTokenProcessor.generateToken(userPrincipal);
+        NamedWriteableRegistry registry = new NamedWriteableRegistry(
+            org.opensearch.common.collect.List.of(
+                new NamedWriteableRegistry.Entry(
+                    PrincipalIdentifierToken.class,
+                    PrincipalIdentifierToken.NAME,
+                    PrincipalIdentifierToken::new
+                )
+            )
+        );
+
+        ExtensionRestRequest request = new ExtensionRestRequest(expectedMethod, expectedUri, expectedRequestIssuerIdentity);
+
+        assertEquals(expectedMethod, request.getMethod());
+        assertEquals(expectedUri, request.getUri());
+        assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                try (NamedWriteableAwareStreamInput nameWritableAwareIn = new NamedWriteableAwareStreamInput(in, registry)) {
+                    request = new ExtensionRestRequest(nameWritableAwareIn);
+                }
+
+                assertEquals(expectedMethod, request.getMethod());
+                assertEquals(expectedUri, request.getUri());
+                assertEquals(expectedRequestIssuerIdentity, request.getRequestIssuerIdentity());
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -42,6 +43,7 @@ import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionResponse;
+import org.opensearch.identity.ExtensionTokenProcessor;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.rest.RestStatus;
@@ -150,7 +152,9 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     @Test
     public void testHandleRestExecuteOnExtensionRequest() throws Exception {
 
-        RestExecuteOnExtensionRequest request = new RestExecuteOnExtensionRequest(Method.GET, "/foo");
+        ExtensionTokenProcessor ext = new ExtensionTokenProcessor(EXTENSION_NAME);
+        Principal userPrincipal = () -> "user1";
+        RestExecuteOnExtensionRequest request = new RestExecuteOnExtensionRequest(Method.GET, "/foo", ext.generateToken(userPrincipal));
         RestExecuteOnExtensionResponse response = extensionsRunner.handleRestExecuteOnExtensionRequest(request);
         // this will fail in test environment with no registered actions
         assertEquals(RestStatus.NOT_FOUND, response.getStatus());


### PR DESCRIPTION
### Description
Adds a principal identity token by accepting it from request coming in from OpenSearch core and adds it to the outgoing request to extensions

### Issues Resolved
Related to : https://github.com/opensearch-project/OpenSearch/pull/4299

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
