### PR TITLE
Add getSettings support for AD

### DIFF
--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -10,7 +10,10 @@ package org.opensearch.sdk;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
+
+import org.opensearch.common.settings.Setting;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -35,6 +38,15 @@ public interface Extension {
      * @return a list of REST handlers (REST actions) this extension handles.
      */
     List<ExtensionRestHandler> getExtensionRestHandlers();
+
+    /**
+     * Gets an optional list of custom {@link Setting} for the extension to register with OpenSearch.
+     *
+     * @return a list of custom settings this extension uses.
+     */
+    default List<Setting<?>> getSettings() {
+        return Collections.emptyList();
+    }
 
     /**
      * Helper method to read extension settings from a YAML file.

--- a/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
@@ -23,6 +23,8 @@ public interface ExtensionRestHandler {
 
     /**
      * The list of {@link Route}s that this ExtensionRestHandler is responsible for handling.
+     *
+     * @return The routes this handler will handle.
      */
     List<Route> routes();
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -22,7 +22,7 @@ import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.rest.RegisterRestActionsRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionRequest;
 import org.opensearch.extensions.rest.RestExecuteOnExtensionResponse;
-import org.opensearch.extensions.settings.RegisterSettingsRequest;
+import org.opensearch.extensions.settings.RegisterCustomSettingsRequest;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.Setting;
@@ -183,7 +183,7 @@ public class ExtensionsRunner {
             setOpensearchNode(opensearchNode);
             extensionTransportService.connectToNode(opensearchNode);
             sendRegisterRestActionsRequest(extensionTransportService);
-            sendRegisterSettingsRequest(extensionTransportService);
+            sendRegisterCustomSettingsRequest(extensionTransportService);
             transportActions.sendRegisterTransportActionsRequest(extensionTransportService, opensearchNode);
         }
     }
@@ -430,15 +430,15 @@ public class ExtensionsRunner {
      *
      * @param transportService  The TransportService defining the connection to OpenSearch.
      */
-    public void sendRegisterSettingsRequest(TransportService transportService) {
+    public void sendRegisterCustomSettingsRequest(TransportService transportService) {
         logger.info("Sending Settings request to OpenSearch");
-        ExtensionStringResponseHandler registerSettingsResponseHandler = new ExtensionStringResponseHandler();
+        ExtensionStringResponseHandler registerCustomSettingsResponseHandler = new ExtensionStringResponseHandler();
         try {
             transportService.sendRequest(
                 opensearchNode,
-                ExtensionsOrchestrator.REQUEST_EXTENSION_REGISTER_SETTINGS,
-                new RegisterSettingsRequest(getUniqueId(), customSettings),
-                registerSettingsResponseHandler
+                ExtensionsOrchestrator.REQUEST_EXTENSION_REGISTER_CUSTOM_SETTINGS,
+                new RegisterCustomSettingsRequest(getUniqueId(), customSettings),
+                registerCustomSettingsResponseHandler
             );
         } catch (Exception e) {
             logger.info("Failed to send Register Settings request to OpenSearch", e);

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -45,7 +45,7 @@ import org.opensearch.sdk.handlers.ActionListenerOnFailureResponseHandler;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.LocalNodeResponseHandler;
-import org.opensearch.sdk.handlers.RegisterRestActionsResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionStringResponseHandler;
 import org.opensearch.search.SearchModule;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.ClusterConnectionManager;
@@ -403,7 +403,7 @@ public class ExtensionsRunner {
     public void sendRegisterRestActionsRequest(TransportService transportService) {
         List<String> extensionRestPaths = extensionRestPathRegistry.getRegisteredPaths();
         logger.info("Sending Register REST Actions request to OpenSearch for " + extensionRestPaths);
-        RegisterRestActionsResponseHandler registerActionsResponseHandler = new RegisterRestActionsResponseHandler();
+        ExtensionStringResponseHandler registerActionsResponseHandler = new ExtensionStringResponseHandler();
         try {
             transportService.sendRequest(
                 opensearchNode,

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -509,7 +509,7 @@ public class ExtensionsRunner {
      *
      * @param timeout  The timeout for the listener in milliseconds. A timeout of 0 means no timeout.
      */
-    public static void startActionListener(int timeout) {
+    public void startActionListener(int timeout) {
         final ActionListener actionListener = new ActionListener();
         actionListener.runActionListener(true, timeout);
     }

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -52,6 +52,7 @@ public class SDKClient {
     }
 
     /**
+     * Close this client.
      *
      * @throws IOException if closing the restClient fails
      */

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -30,6 +30,9 @@ public class TransportActions {
 
     /**
      * Constructor for TransportActions. Creates a map of transportActions for this extension.
+     *
+     * @param <Request> the TransportAction request
+     * @param <Response> the TransportAction response
      * @param transportActions is the list of actions the extension would like to register with OpenSearch.
      */
     public <Request extends ActionRequest, Response extends ActionResponse> TransportActions(

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -15,7 +15,7 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.extensions.ExtensionsOrchestrator;
 import org.opensearch.extensions.RegisterTransportActionsRequest;
-import org.opensearch.sdk.handlers.ExtensionResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionBooleanResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.util.HashMap;
@@ -46,7 +46,7 @@ public class TransportActions {
      */
     public void sendRegisterTransportActionsRequest(TransportService transportService, DiscoveryNode opensearchNode) {
         logger.info("Sending Register Transport Actions request to OpenSearch");
-        ExtensionResponseHandler registerTransportActionsResponseHandler = new ExtensionResponseHandler();
+        ExtensionBooleanResponseHandler registerTransportActionsResponseHandler = new ExtensionBooleanResponseHandler();
         try {
             transportService.sendRequest(
                 opensearchNode,

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionBooleanResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionBooleanResponseHandler.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 /**
  * This class handles the response {{@link org.opensearch.extensions.ExtensionBooleanResponse }} from OpenSearch to Extension.
  */
-public class ExtensionResponseHandler implements TransportResponseHandler<ExtensionBooleanResponse> {
-    private static final Logger logger = LogManager.getLogger(ExtensionResponseHandler.class);
+public class ExtensionBooleanResponseHandler implements TransportResponseHandler<ExtensionBooleanResponse> {
+    private static final Logger logger = LogManager.getLogger(ExtensionBooleanResponseHandler.class);
 
     @Override
     public void handleResponse(ExtensionBooleanResponse response) {

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionStringResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionStringResponseHandler.java
@@ -10,29 +10,26 @@ package org.opensearch.sdk.handlers;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.io.stream.StreamInput;
-import org.opensearch.extensions.rest.RegisterRestActionsResponse;
-import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.extensions.ExtensionStringResponse;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
-import org.opensearch.transport.TransportService;
-
 import java.io.IOException;
 
 /**
- * This class handles the response from OpenSearch to a {@link ExtensionsRunner#sendRegisterRestActionsRequest(TransportService)} call.
+ * This class handles the response from OpenSearch to call returning an {@link ExtensionStringResponse}.
  */
-public class RegisterRestActionsResponseHandler implements TransportResponseHandler<RegisterRestActionsResponse> {
-    private static final Logger logger = LogManager.getLogger(RegisterRestActionsResponseHandler.class);
+public class ExtensionStringResponseHandler implements TransportResponseHandler<ExtensionStringResponse> {
+    private static final Logger logger = LogManager.getLogger(ExtensionStringResponseHandler.class);
 
     @Override
-    public void handleResponse(RegisterRestActionsResponse response) {
+    public void handleResponse(ExtensionStringResponse response) {
         logger.info("received {}", response.getResponse());
     }
 
     @Override
     public void handleException(TransportException exp) {
-        logger.info("RegisterActionsRequest failed", exp);
+        logger.info("Request failed", exp);
     }
 
     @Override
@@ -41,7 +38,7 @@ public class RegisterRestActionsResponseHandler implements TransportResponseHand
     }
 
     @Override
-    public RegisterRestActionsResponse read(StreamInput in) throws IOException {
-        return new RegisterRestActionsResponse(in);
+    public ExtensionStringResponse read(StreamInput in) throws IOException {
+        return new ExtensionStringResponse(in);
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionTransportActionsAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionTransportActionsAPI.java
@@ -13,7 +13,7 @@ import org.opensearch.common.io.stream.Writeable;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.extensions.ExtensionsOrchestrator;
-import org.opensearch.sdk.handlers.ExtensionResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionBooleanResponseHandler;
 import org.opensearch.tasks.Task;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
@@ -87,7 +87,7 @@ public class TestExtensionTransportActionsAPI extends OpenSearchTestCase {
             any(),
             eq(ExtensionsOrchestrator.REQUEST_EXTENSION_REGISTER_TRANSPORT_ACTIONS),
             any(),
-            any(ExtensionResponseHandler.class)
+            any(ExtensionBooleanResponseHandler.class)
         );
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -49,7 +49,7 @@ import org.opensearch.sdk.handlers.ActionListenerOnFailureResponseHandler;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.LocalNodeResponseHandler;
-import org.opensearch.sdk.handlers.RegisterRestActionsResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionStringResponseHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
@@ -198,6 +198,6 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         extensionsRunner.sendRegisterRestActionsRequest(transportService);
 
-        verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(RegisterRestActionsResponseHandler.class));
+        verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(ExtensionStringResponseHandler.class));
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -202,9 +202,9 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     }
 
     @Test
-    public void testRegisterSettingsRequest() {
+    public void testRegisterCustomSettingsRequest() {
 
-        extensionsRunner.sendRegisterSettingsRequest(transportService);
+        extensionsRunner.sendRegisterCustomSettingsRequest(transportService);
 
         verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(ExtensionStringResponseHandler.class));
     }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -200,4 +200,12 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(ExtensionStringResponseHandler.class));
     }
+
+    @Test
+    public void testRegisterSettingsRequest() {
+
+        extensionsRunner.sendRegisterSettingsRequest(transportService);
+
+        verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(ExtensionStringResponseHandler.class));
+    }
 }


### PR DESCRIPTION
Companion PR: https://github.com/opensearch-project/OpenSearch/pull/4519

NOTE: Gradle Check is failing due to new classes on the Companion PR.   Check completes locally when the other PR branch is published to Maven Local.  Re-run check after merging the companion PR.

NOTE: Merging the compainion PR will break `main` on SDK project until this PR (or at least the first commit from it) is merged.  Merge this PR shortly after merging the companion PR.

### Description

Registers custom Settings from an extension as dynamic settings in the Settings Module.

The pattern is similar to registering REST actions.

Recommend reviewers [evaluate the commits separately](https://github.com/opensearch-project/opensearch-sdk-java/pull/147/commits) to simplify review.  Explanation follows:
 - The companion PR combined `RegisterRestActionsResponse` and a response for the settings to `ExtensionStringResponse`. Merging the companion PR will break `main`; this first commit fixes the rename.
 - Since we have a `ExtensionStringResponseHandler` it made sense to rename the handler for the boolean response to align.
 - Adding the `static` modifier in #87 created compiler warnings for accessing static methods non-statically.  I undid that change.
 - The fourth commit actually sends the settings to OpenSearch and is the main point of this PR! 
 - I fixed up some javadocs.

### Issues Resolved
Fixes #79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
