### PR TITLE
Transport service 

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -91,8 +91,13 @@ public class ExtensionsRunner {
     private ExtensionsIndicesModuleRequestHandler extensionsIndicesModuleRequestHandler = new ExtensionsIndicesModuleRequestHandler();
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
         new ExtensionsIndicesModuleNameRequestHandler();
+<<<<<<< HEAD
     private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
     private NettyTransport nettyTransport = new NettyTransport();
+=======
+    private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler();
+    private NettyTransport nettyTransport = new NettyTransport(this);
+>>>>>>> handle transportService object
 
     /*
      * TODO: expose an interface for extension to register actions

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -10,6 +10,7 @@ package org.opensearch.sdk;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.NamedWriteableRegistryParseRequest;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
@@ -72,6 +73,7 @@ public class ExtensionsRunner {
     /**
      * This field is initialized by a call from {@link ExtensionsInitRequestHandler}.
      */
+    @Nullable
     public TransportService extensionTransportService = null;
     // The routes and classes which handle the REST requests
     private final ExtensionRestPathRegistry extensionRestPathRegistry = new ExtensionRestPathRegistry();

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -139,7 +139,7 @@ public class ExtensionsRunner {
         // save custom transport actions
         this.transportActions = new TransportActions(extension.getActions());
         // initialize the transport service
-        nettyTransport.initializeExtensionTransportService(this.getSettings(), this);
+        nettyTransport.initializeExtensionTransportService(this.getSettings());
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -92,7 +92,6 @@ public class ExtensionsRunner {
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
         new ExtensionsIndicesModuleNameRequestHandler();
     private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
-    private NettyTransport nettyTransport = new NettyTransport(this);
 
     /*
      * TODO: expose an interface for extension to register actions
@@ -131,8 +130,6 @@ public class ExtensionsRunner {
         this.customSettings = extension.getSettings();
         // save custom transport actions
         this.transportActions = new TransportActions(extension.getActions());
-        // initialize the transport service
-        nettyTransport.initializeExtensionTransportService(this.getSettings());
     }
 
     /**
@@ -449,8 +446,9 @@ public class ExtensionsRunner {
      */
     public static void run(Extension extension) throws IOException {
         logger.info("Starting extension " + extension.getExtensionSettings().getExtensionName());
-        @SuppressWarnings("unused")
         ExtensionsRunner runner = new ExtensionsRunner(extension);
+        // initialize the transport service
+        new NettyTransport(runner).initializeExtensionTransportService(runner.getSettings());
         runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -10,7 +10,6 @@ package org.opensearch.sdk;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.node.DiscoveryNode;
-import org.opensearch.common.Nullable;
 import org.opensearch.common.io.stream.NamedWriteableRegistryParseRequest;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
@@ -73,7 +72,6 @@ public class ExtensionsRunner {
     /**
      * This field is initialized by a call from {@link ExtensionsInitRequestHandler}.
      */
-    @Nullable
     public TransportService extensionTransportService = null;
     // The routes and classes which handle the REST requests
     private final ExtensionRestPathRegistry extensionRestPathRegistry = new ExtensionRestPathRegistry();

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -91,13 +91,8 @@ public class ExtensionsRunner {
     private ExtensionsIndicesModuleRequestHandler extensionsIndicesModuleRequestHandler = new ExtensionsIndicesModuleRequestHandler();
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
         new ExtensionsIndicesModuleNameRequestHandler();
-<<<<<<< HEAD
     private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
-    private NettyTransport nettyTransport = new NettyTransport();
-=======
-    private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler();
     private NettyTransport nettyTransport = new NettyTransport(this);
->>>>>>> handle transportService object
 
     /*
      * TODO: expose an interface for extension to register actions

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -40,7 +40,7 @@ import static org.opensearch.common.UUIDs.randomBase64UUID;
 
 public class NettyTransport {
     private static final String NODE_NAME_SETTING = "node.name";
-    private ExtensionsRunner extensionsRunner;
+    private final ExtensionsRunner extensionsRunner;
     private final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
     };
 
@@ -51,11 +51,6 @@ public class NettyTransport {
     public NettyTransport(ExtensionsRunner extensionsRunner) {
         this.extensionsRunner = extensionsRunner;
     }
-
-    /**
-     * empty constructor for getNetty4Transport method call
-     */
-    public NettyTransport() {}
 
     /**
      * Initializes a Netty4Transport object. This object will be wrapped in a {@link TransportService} object.
@@ -106,8 +101,6 @@ public class NettyTransport {
         ThreadPool threadPool = new ThreadPool(settings);
 
         Netty4Transport transport = getNetty4Transport(settings, threadPool);
-
-        // delete stop
 
         // create transport service
         TransportService transportService = new TransportService(

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -40,8 +40,22 @@ import static org.opensearch.common.UUIDs.randomBase64UUID;
 
 public class NettyTransport {
     private static final String NODE_NAME_SETTING = "node.name";
+    private ExtensionsRunner extensionsRunner;
     private final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
     };
+
+    /**
+     *
+     * @param extensionsRunner method to call
+     */
+    public NettyTransport(ExtensionsRunner extensionsRunner) {
+        this.extensionsRunner = extensionsRunner;
+    }
+
+    /**
+     * empty constructor for getNetty4Transport method call
+     */
+    public NettyTransport() {}
 
     /**
      * Initializes a Netty4Transport object. This object will be wrapped in a {@link TransportService} object.
@@ -85,22 +99,18 @@ public class NettyTransport {
      * Initializes the TransportService object for this extension. This object will control communication between the extension and OpenSearch.
      *
      * @param settings  The transport settings to configure.
-     * @param extensionsRunner method to call
      * @return The initialized TransportService object.
      */
-    public TransportService initializeExtensionTransportService(Settings settings, ExtensionsRunner extensionsRunner) {
+    public TransportService initializeExtensionTransportService(Settings settings) {
 
         ThreadPool threadPool = new ThreadPool(settings);
 
         Netty4Transport transport = getNetty4Transport(settings, threadPool);
 
-        // Stop any existing transport service
-        if (extensionsRunner.extensionTransportService != null) {
-            extensionsRunner.extensionTransportService.stop();
-        }
+        // delete stop
 
         // create transport service
-        extensionsRunner.extensionTransportService = new TransportService(
+        TransportService transportService = new TransportService(
             settings,
             transport,
             threadPool,
@@ -113,8 +123,8 @@ public class NettyTransport {
             null,
             emptySet()
         );
-        extensionsRunner.startTransportService(extensionsRunner.extensionTransportService);
-        return extensionsRunner.extensionTransportService;
+        extensionsRunner.startTransportService(transportService);
+        return transportService;
     }
 
 }

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -45,8 +45,7 @@ public class NettyTransport {
     };
 
     /**
-     *
-     * @param extensionsRunner method to call
+     * @param extensionsRunner Instantiate this object with a reference to the ExtensionsRunner.
      */
     public NettyTransport(ExtensionsRunner extensionsRunner) {
         this.extensionsRunner = extensionsRunner;

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.bytes.BytesArray;
@@ -69,6 +70,7 @@ import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
 import org.opensearch.common.settings.WriteableSetting;
 
+@ResourceLock("transportService")
 public class TestExtensionsRunner extends OpenSearchTestCase {
 
     private static final String EXTENSION_NAME = "sample-extension";

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -80,14 +79,11 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     private ExtensionsRunner extensionsRunner;
     private TransportService transportService;
 
-    private TransportService initialTransportService;
-
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         this.extensionsRunner = new ExtensionsRunnerForTest();
-        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.transportService = spy(
             new TransportService(
                 Settings.EMPTY,
@@ -99,17 +95,6 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
                 Collections.emptySet()
             )
         );
-    }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        if (initialTransportService != null) {
-            this.initialTransportService.stop();
-            this.initialTransportService.close();
-            Thread.sleep(1000);
-        }
     }
 
     // test manager method invokes start on transport service

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.bytes.BytesArray;
@@ -69,7 +68,6 @@ import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportService;
 import org.opensearch.common.settings.WriteableSetting;
 
-@ResourceLock("transportService")
 public class TestExtensionsRunner extends OpenSearchTestCase {
 
     private static final String EXTENSION_NAME = "sample-extension";

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -31,7 +31,6 @@ public class TestNetty4Transport extends OpenSearchTestCase {
     @BeforeEach
     public void setUp() throws IOException {
         this.threadPool = new TestThreadPool("test");
-        this.extensionsRunner = new ExtensionsRunner();
         this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
@@ -24,7 +23,6 @@ import org.opensearch.transport.TransportSettings;
 
 import org.opensearch.transport.netty4.Netty4Transport;
 
-@ResourceLock("transportService")
 public class TestNetty4Transport extends OpenSearchTestCase {
 
     private ThreadPool threadPool;

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -12,12 +12,15 @@
 package org.opensearch.sdk;
 
 import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
 import org.opensearch.transport.TransportSettings;
 
 import org.opensearch.transport.netty4.Netty4Transport;
@@ -27,11 +30,25 @@ public class TestNetty4Transport extends OpenSearchTestCase {
     private ThreadPool threadPool;
     private ExtensionsRunner extensionsRunner;
     private NettyTransport nettyTransport;
+    private TransportService initialTransportService;
 
     @BeforeEach
     public void setUp() throws IOException {
         this.threadPool = new TestThreadPool("test");
+        this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.nettyTransport = new NettyTransport(extensionsRunner);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (initialTransportService != null) {
+            this.initialTransportService.stop();
+            this.initialTransportService.close();
+            Thread.sleep(1000);
+        }
     }
 
     // test Netty can bind to multiple ports, default and additional client

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -25,11 +25,14 @@ import org.opensearch.transport.netty4.Netty4Transport;
 public class TestNetty4Transport extends OpenSearchTestCase {
 
     private ThreadPool threadPool;
-    private NettyTransport nettyTransport = new NettyTransport();
+    private ExtensionsRunner extensionsRunner;
+    private NettyTransport nettyTransport;
 
     @BeforeEach
     public void setUp() throws IOException {
         this.threadPool = new TestThreadPool("test");
+        this.extensionsRunner = new ExtensionsRunner();
+        this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 
     // test Netty can bind to multiple ports, default and additional client

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -13,7 +13,6 @@ package org.opensearch.sdk;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -21,7 +20,6 @@ import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.TransportService;
 import org.opensearch.transport.TransportSettings;
 
 import org.opensearch.transport.netty4.Netty4Transport;
@@ -32,25 +30,12 @@ public class TestNetty4Transport extends OpenSearchTestCase {
     private ThreadPool threadPool;
     private ExtensionsRunner extensionsRunner;
     private NettyTransport nettyTransport;
-    private TransportService initialTransportService;
 
     @BeforeEach
     public void setUp() throws IOException {
         this.threadPool = new TestThreadPool("test");
         this.extensionsRunner = new ExtensionsRunnerForTest();
-        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.nettyTransport = new NettyTransport(extensionsRunner);
-    }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        if (initialTransportService != null) {
-            this.initialTransportService.stop();
-            this.initialTransportService.close();
-            Thread.sleep(1000);
-        }
     }
 
     // test Netty can bind to multiple ports, default and additional client

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
@@ -25,6 +26,7 @@ import org.opensearch.transport.TransportSettings;
 
 import org.opensearch.transport.netty4.Netty4Transport;
 
+@ResourceLock("transportService")
 public class TestNetty4Transport extends OpenSearchTestCase {
 
     private ThreadPool threadPool;

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -35,7 +35,9 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private final int port = 7777;
     private final String host = "127.0.0.1";
     private volatile String clientResult;
+    private ExtensionsRunner extensionsRunner;
     private NettyTransport nettyTransport = new NettyTransport();
+    private NettyTransport nettyTransport1 = new NettyTransport(extensionsRunner);
 
     @Override
     @BeforeEach
@@ -147,7 +149,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
         // retrieve transport service
         ExtensionsRunner extensionsRunner = new ExtensionsRunnerForTest();
         // start transport service
-        TransportService transportService = nettyTransport.initializeExtensionTransportService(settings, extensionsRunner);
+        TransportService transportService = nettyTransport1.initializeExtensionTransportService(settings);
 
         assertEquals(Lifecycle.State.STARTED, transportService.lifecycleState());
 

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.sdk;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -40,7 +39,6 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private volatile String clientResult;
     private ExtensionsRunner extensionsRunner;
     private NettyTransport nettyTransport;
-    private TransportService initialTransportService;
 
     @Override
     @BeforeEach
@@ -53,19 +51,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
             .put(TransportSettings.PORT.getKey(), port)
             .build();
         this.extensionsRunner = new ExtensionsRunnerForTest();
-        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.nettyTransport = new NettyTransport(extensionsRunner);
-    }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        if (initialTransportService != null) {
-            this.initialTransportService.stop();
-            this.initialTransportService.close();
-            Thread.sleep(1000);
-        }
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.sdk;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.component.Lifecycle;
@@ -37,6 +38,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private volatile String clientResult;
     private ExtensionsRunner extensionsRunner;
     private NettyTransport nettyTransport;
+    private TransportService initialTransportService;
 
     @Override
     @BeforeEach
@@ -48,7 +50,20 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
             .put(TransportSettings.BIND_HOST.getKey(), host)
             .put(TransportSettings.PORT.getKey(), port)
             .build();
+        this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.nettyTransport = new NettyTransport(extensionsRunner);
+    }
+    
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (initialTransportService != null) {
+            this.initialTransportService.stop();
+            this.initialTransportService.close();
+            Thread.sleep(1000);
+        }
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -48,7 +48,6 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
             .put(TransportSettings.BIND_HOST.getKey(), host)
             .put(TransportSettings.PORT.getKey(), port)
             .build();
-        this.extensionsRunner = new ExtensionsRunner();
         this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -14,6 +14,7 @@ package org.opensearch.sdk;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.settings.Settings;
@@ -30,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
 
+@ResourceLock("transportService")
 public class TransportCommunicationIT extends OpenSearchIntegTestCase {
 
     private Settings settings;
@@ -54,7 +56,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
         this.initialTransportService = extensionsRunner.extensionTransportService;
         this.nettyTransport = new NettyTransport(extensionsRunner);
     }
-    
+
     @Override
     @AfterEach
     public void tearDown() throws Exception {

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -36,12 +36,11 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private final String host = "127.0.0.1";
     private volatile String clientResult;
     private ExtensionsRunner extensionsRunner;
-    private NettyTransport nettyTransport = new NettyTransport();
-    private NettyTransport nettyTransport1 = new NettyTransport(extensionsRunner);
+    private NettyTransport nettyTransport;
 
     @Override
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
 
         // Configure settings for transport serivce using the same port number used to bind the client
         settings = Settings.builder()
@@ -49,6 +48,8 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
             .put(TransportSettings.BIND_HOST.getKey(), host)
             .put(TransportSettings.PORT.getKey(), port)
             .build();
+        this.extensionsRunner = new ExtensionsRunner();
+        this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 
     @Test
@@ -149,7 +150,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
         // retrieve transport service
         ExtensionsRunner extensionsRunner = new ExtensionsRunnerForTest();
         // start transport service
-        TransportService transportService = nettyTransport1.initializeExtensionTransportService(settings);
+        TransportService transportService = nettyTransport.initializeExtensionTransportService(settings);
 
         assertEquals(Lifecycle.State.STARTED, transportService.lifecycleState());
 

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -13,7 +13,6 @@ package org.opensearch.sdk;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.opensearch.common.component.Lifecycle;
 import org.opensearch.common.network.NetworkAddress;
 import org.opensearch.common.settings.Settings;
@@ -30,7 +29,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
 
-@ResourceLock("transportService")
 public class TransportCommunicationIT extends OpenSearchIntegTestCase {
 
     private Settings settings;


### PR DESCRIPTION
### Description
To avoid passing the object of `extensionRunner` in `ExtensionsRunner` main function, move all of the required methods and variables to `NettyTransport` file
Address comment from [previous PR](https://github.com/opensearch-project/opensearch-sdk-java/pull/166).

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/pull/166
https://github.com/opensearch-project/opensearch-sdk-java/issues/116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
