### PR TITLE
Refactor ExtensionsRunner test code out of production source tree

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -17,11 +17,6 @@ public class ExtensionSettings {
     private String hostPort;
 
     /**
-     * Path to extension.yml file for testing. Internal use only.
-     */
-    static final String EXTENSION_DESCRIPTOR = "src/test/resources/extension.yml";
-
-    /**
      * Jackson requires a default constructor.
      */
     @SuppressWarnings("unused")

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -7,9 +7,6 @@
  */
 package org.opensearch.sdk;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -50,10 +47,8 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.TransportSettings;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,27 +110,12 @@ public class ExtensionsRunner {
     UpdateSettingsRequestHandler updateSettingsRequestHandler = new UpdateSettingsRequestHandler();
 
     /**
-     * Instantiates a new Extensions Runner using test settings.
-     *
-     * @throws IOException if the runner failed to read settings or API.
-     */
-    public ExtensionsRunner() throws IOException {
-        ExtensionSettings extensionSettings = readExtensionSettings();
-        this.settings = Settings.builder()
-            .put(NODE_NAME_SETTING, extensionSettings.getExtensionName())
-            .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress())
-            .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
-            .build();
-        this.customSettings = Collections.emptyList();
-    }
-
-    /**
      * Instantiates a new Extensions Runner using the specified extension.
      *
      * @param extension  The settings with which to start the runner.
      * @throws IOException if the runner failed to read settings or API.
      */
-    private ExtensionsRunner(Extension extension) throws IOException {
+    protected ExtensionsRunner(Extension extension) throws IOException {
         ExtensionSettings extensionSettings = extension.getExtensionSettings();
         this.settings = Settings.builder()
             .put(NODE_NAME_SETTING, extensionSettings.getExtensionName())
@@ -152,14 +132,6 @@ public class ExtensionsRunner {
         this.customSettings = extension.getSettings();
         // initialize the transport service
         nettyTransport.initializeExtensionTransportService(this.getSettings(), this);
-        // start listening on configured port and wait for connection from OpenSearch
-        this.startActionListener(0);
-    }
-
-    private static ExtensionSettings readExtensionSettings() throws IOException {
-        File file = new File(ExtensionSettings.EXTENSION_DESCRIPTOR);
-        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-        return objectMapper.readValue(file, ExtensionSettings.class);
     }
 
     /**
@@ -478,21 +450,6 @@ public class ExtensionsRunner {
         logger.info("Starting extension " + extension.getExtensionSettings().getExtensionName());
         @SuppressWarnings("unused")
         ExtensionsRunner runner = new ExtensionsRunner(extension);
-    }
-
-    /**
-     * Run the Extension. For internal/testing purposes only. Imports settings and sets up Transport Service listening for incoming connections.
-     *
-     * @param args  Unused
-     * @throws IOException if the runner failed to connect to the OpenSearch cluster.
-     */
-    public static void main(String[] args) throws IOException {
-
-        ExtensionsRunner extensionsRunner = new ExtensionsRunner();
-
-        // initialize the transport service
-        extensionsRunner.nettyTransport.initializeExtensionTransportService(extensionsRunner.getSettings(), extensionsRunner);
-        // start listening on configured port and wait for connection from OpenSearch
-        extensionsRunner.startActionListener(0);
+        runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -54,7 +54,7 @@ public class TransportActions {
             transportService.sendRequest(
                 opensearchNode,
                 ExtensionsOrchestrator.REQUEST_EXTENSION_REGISTER_TRANSPORT_ACTIONS,
-                new RegisterTransportActionsRequest(transportActions),
+                new RegisterTransportActionsRequest("", transportActions),
                 registerTransportActionsResponseHandler
             );
         } catch (Exception e) {

--- a/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
+++ b/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
@@ -1,0 +1,32 @@
+package org.opensearch.sdk;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An Extension Runner for testing using test settings.
+ */
+public class ExtensionsRunnerForTest extends ExtensionsRunner {
+
+    /**
+     * Instantiates a new Extensions Runner using test settings.
+     *
+     * @throws IOException if the runner failed to read settings or API.
+     */
+    public ExtensionsRunnerForTest() throws IOException {
+        super(new Extension() {
+            @Override
+            public ExtensionSettings getExtensionSettings() {
+                return new ExtensionSettings("sample-extension", "127.0.0.1", "4532");
+            }
+
+            @Override
+            public List<ExtensionRestHandler> getExtensionRestHandlers() {
+                return Collections.emptyList();
+            }
+        });
+
+    }
+
+}

--- a/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
@@ -9,14 +9,14 @@ import org.opensearch.test.OpenSearchTestCase;
 import java.io.File;
 
 public class TestExtensionSettings extends OpenSearchTestCase {
-
+    private static final String EXTENSION_DESCRIPTOR = "src/test/resources/extension.yml";
     private ExtensionSettings extensionSettings;
 
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        File file = new File(ExtensionSettings.EXTENSION_DESCRIPTOR);
+        File file = new File(EXTENSION_DESCRIPTOR);
         ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
         extensionSettings = objectMapper.readValue(file, ExtensionSettings.class);
     }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.Version;
@@ -77,11 +78,14 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     private ExtensionsRunner extensionsRunner;
     private TransportService transportService;
 
+    private TransportService initialTransportService;
+
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        this.extensionsRunner = new ExtensionsRunner();
+        this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.initialTransportService = extensionsRunner.extensionTransportService;
         this.transportService = spy(
             new TransportService(
                 Settings.EMPTY,
@@ -93,6 +97,17 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
                 Collections.emptySet()
             )
         );
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (initialTransportService != null) {
+            this.initialTransportService.stop();
+            this.initialTransportService.close();
+            Thread.sleep(1000);
+        }
     }
 
     // test manager method invokes start on transport service

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -145,7 +145,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private void startTransportandClient(Settings settings, Thread client) throws IOException, InterruptedException {
 
         // retrieve transport service
-        ExtensionsRunner extensionsRunner = new ExtensionsRunner();
+        ExtensionsRunner extensionsRunner = new ExtensionsRunnerForTest();
         // start transport service
         TransportService transportService = nettyTransport.initializeExtensionTransportService(settings, extensionsRunner);
 


### PR DESCRIPTION
### Description
Remove `ExtensionsRunner` constructor which was used only in tests

### Issues Resolved
Closes #171 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
