### PR TITLE
Updated dev guide to remove gradlew run

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -38,12 +38,6 @@ The work done to support the extensions framework is located on the `feature/ext
 
 Navigate to the directory that OpenSearch-SDK-Java has been cloned to.
 
-You can execute just the SDK's `ExtensionsRunner` main method with test settings using `./gradlew run`.
-
-```
-./gradlew run
-```
-
 You can execute the sample Hello World extension using the `helloWorld` task:
 
 ```


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Coming from #172 we have removed the `main` function as SDK will be treated as a library. From now instead of testing the SDK, let's run the sample extension directly.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
