### PR TITLE
Temporarily redirect gradle run to helloWorld

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,11 @@ apply plugin: 'application'
 apply from: 'gradle/formatting.gradle'
 apply plugin: 'maven-publish'
 
-mainClassName = 'org.opensearch.sdk.ExtensionsRunner'
+// Temporary to keep "gradle run" working
+// TODO: change this to an extension designed for testing instead of duplicating a sample
+// https://github.com/opensearch-project/opensearch-sdk-java/issues/175
+mainClassName = 'org.opensearch.sdk.sample.helloworld.HelloWorldExtension'
+
   
 group 'org.opensearch.sdk'
 version '1.0.0-SNAPSHOT'


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
Temporarily redirect `gradle run` to the Hello World extension so devs can use it until we find a suitable replacement.

### Issues Resolved

Temporary workaround for #175 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
