### PR TITLE
Updating Netty Logging to only display errors and default logging to debug

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,9 +9,10 @@
         </File>
     </Appenders>
     <Loggers>
-        <Root level="trace">
+        <Root level="debug">
             <AppenderRef ref="ConsoleAppender" />
             <AppenderRef ref="FileAppender"/>
         </Root>
+        <logger name="io.netty.util" level="ERROR"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Updating Netty logging to only print out errors. 
Netty is using reflective access which is denied by default for Java > 8. 
See: https://github.com/netty/netty/issues/7817

As recommendation says, its just a warning but its not fatal problems for the application. For SDK we really dont care about Netty debug/trace logs, error should be good enough.

This PR also updates default logging to debug as trace is not really helping a human unless we really want to debug core problems. 

### Issues Resolved
Closes #180 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
