### PR TITLE
Re: Updating Netty Logging to only display errors and default logging to debug

### DIFF
--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -9,9 +9,10 @@
         </File>
     </Appenders>
     <Loggers>
-        <Root level="trace">
+        <Root level="debug">
             <AppenderRef ref="ConsoleAppender" />
             <AppenderRef ref="FileAppender"/>
-        </Root>
+        </Root>i
+    <logger name="io.netty.util" level="ERROR"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Re-PR: https://github.com/opensearch-project/opensearch-sdk-java/pull/181 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
