### PR TITLE
Transport service

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -459,10 +459,10 @@ public class ExtensionsRunner {
      */
     public static void run(Extension extension) throws IOException {
         logger.info("Starting extension " + extension.getExtensionSettings().getExtensionName());
-        @SuppressWarnings("unused")
         ExtensionsRunner runner = new ExtensionsRunner(extension);
         // initialize the transport service
-        new NettyTransport(runner).initializeExtensionTransportService(runner.getSettings(), new ThreadPool(runner.getSettings()), runner);
+        NettyTransport nettyTransport = new NettyTransport(runner);
+        nettyTransport.initializeExtensionTransportService(runner.getSettings(), new ThreadPool(runner.getSettings()), runner);
         runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -91,7 +91,7 @@ public class ExtensionsRunner {
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
         new ExtensionsIndicesModuleNameRequestHandler();
     private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
-    private NettyTransport nettyTransport = new NettyTransport();
+
     private SDKClient client = new SDKClient();
 
     /*
@@ -131,9 +131,9 @@ public class ExtensionsRunner {
         this.customSettings = extension.getSettings();
         // save custom transport actions
         this.transportActions = new TransportActions(extension.getActions());
-        // initialize the transport service
+
         ThreadPool threadPool = new ThreadPool(this.getSettings());
-        nettyTransport.initializeExtensionTransportService(this.getSettings(), threadPool, this);
+
         // create components
         extension.createComponents(client, null, threadPool);
     }
@@ -461,6 +461,8 @@ public class ExtensionsRunner {
         logger.info("Starting extension " + extension.getExtensionSettings().getExtensionName());
         @SuppressWarnings("unused")
         ExtensionsRunner runner = new ExtensionsRunner(extension);
+        // initialize the transport service
+        new NettyTransport(runner).initializeExtensionTransportService(runner.getSettings());
         runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -462,7 +462,7 @@ public class ExtensionsRunner {
         @SuppressWarnings("unused")
         ExtensionsRunner runner = new ExtensionsRunner(extension);
         // initialize the transport service
-        new NettyTransport(runner).initializeExtensionTransportService(runner.getSettings());
+        new NettyTransport(runner).initializeExtensionTransportService(runner.getSettings(), new ThreadPool(runner.getSettings()), runner);
         runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -40,8 +40,16 @@ import static org.opensearch.common.UUIDs.randomBase64UUID;
 
 public class NettyTransport {
     private static final String NODE_NAME_SETTING = "node.name";
+    private final ExtensionsRunner extensionsRunner;
     private final TransportInterceptor NOOP_TRANSPORT_INTERCEPTOR = new TransportInterceptor() {
     };
+
+    /**
+     * @param extensionsRunner Instantiate this object with a reference to the ExtensionsRunner.
+     */
+    public NettyTransport(ExtensionsRunner extensionsRunner) {
+        this.extensionsRunner = extensionsRunner;
+    }
 
     /**
      * Initializes a Netty4Transport object. This object will be wrapped in a {@link TransportService} object.
@@ -103,7 +111,7 @@ public class NettyTransport {
         }
 
         // create transport service
-        extensionsRunner.extensionTransportService = new TransportService(
+        TransportService transportService = new TransportService(
             settings,
             transport,
             threadPool,
@@ -116,8 +124,8 @@ public class NettyTransport {
             null,
             emptySet()
         );
-        extensionsRunner.startTransportService(extensionsRunner.extensionTransportService);
-        return extensionsRunner.extensionTransportService;
+        extensionsRunner.startTransportService(transportService);
+        return transportService;
     }
 
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -29,7 +29,6 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.HashMap;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.Version;
@@ -76,14 +75,12 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     private ExtensionsRunner extensionsRunner;
     private TransportService transportService;
 
-    private TransportService initialTransportService;
-
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         this.extensionsRunner = new ExtensionsRunnerForTest();
-        this.initialTransportService = extensionsRunner.extensionTransportService;
+
         this.transportService = spy(
             new TransportService(
                 Settings.EMPTY,
@@ -95,17 +92,6 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
                 Collections.emptySet()
             )
         );
-    }
-
-    @Override
-    @AfterEach
-    public void tearDown() throws Exception {
-        super.tearDown();
-        if (initialTransportService != null) {
-            this.initialTransportService.stop();
-            this.initialTransportService.close();
-            Thread.sleep(1000);
-        }
     }
 
     // test manager method invokes start on transport service

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -12,6 +12,7 @@
 package org.opensearch.sdk;
 
 import java.io.IOException;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.component.Lifecycle;
@@ -25,11 +26,14 @@ import org.opensearch.transport.netty4.Netty4Transport;
 public class TestNetty4Transport extends OpenSearchTestCase {
 
     private ThreadPool threadPool;
-    private NettyTransport nettyTransport = new NettyTransport();
+    private ExtensionsRunner extensionsRunner;
+    private NettyTransport nettyTransport;
 
     @BeforeEach
     public void setUp() throws IOException {
         this.threadPool = new TestThreadPool("test");
+        this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 
     // test Netty can bind to multiple ports, default and additional client

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -12,7 +12,6 @@
 package org.opensearch.sdk;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.component.Lifecycle;

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -35,11 +35,12 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
     private final int port = 7777;
     private final String host = "127.0.0.1";
     private volatile String clientResult;
-    private NettyTransport nettyTransport = new NettyTransport();
+    private ExtensionsRunner extensionsRunner;
+    private NettyTransport nettyTransport;
 
     @Override
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws IOException {
 
         // Configure settings for transport serivce using the same port number used to bind the client
         settings = Settings.builder()
@@ -47,6 +48,8 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
             .put(TransportSettings.BIND_HOST.getKey(), host)
             .put(TransportSettings.PORT.getKey(), port)
             .build();
+        this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.nettyTransport = new NettyTransport(extensionsRunner);
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

To avoid passing the object of `extensionRunner` in `ExtensionsRunner` main function, move all of the required methods and variables to `NettyTransport` file
Address comment from [previous PR](https://github.com/opensearch-project/opensearch-sdk-java/pull/166).
Fixed the bind errors by moving the netty initialization out of the constructor in the Extensions Runner and backed out the "hack" solution from intervening PR. 


### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/pull/166
https://github.com/opensearch-project/opensearch-sdk-java/issues/116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
