### PR TITLE
Compiler warning

### DIFF
--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public class TransportActions {
     private final Logger logger = LogManager.getLogger(TransportActions.class);
-    private Map<String, Class> transportActions;
+    private Map<String, Class<?>> transportActions;
 
     /**
      * Constructor for TransportActions. Creates a map of transportActions for this extension.

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -26,7 +26,7 @@ import java.util.Map;
  */
 public class TransportActions {
     private final Logger logger = LogManager.getLogger(TransportActions.class);
-    private Map<String, Class<?>> transportActions;
+    private Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> transportActions;
 
     /**
      * Constructor for TransportActions. Creates a map of transportActions for this extension.


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
Add Add unbounded wildcard for `transportActions` in `TransportActions.java` to clean up compiler warning.
Equivalent PR on OpenSearch:  https://github.com/opensearch-project/OpenSearch/pull/4796
### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
