### PR TITLE
Run spotless check before gradle check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,12 @@ on: [push, pull_request]
 jobs:
   spotless:
     runs-on: ubuntu-latest
-      name: Spotless Check
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        - name: Spotless Check
-          run: ./gradlew spotlessCheck
+      - name: Spotless Check
+        run: ./gradlew spotlessCheck
   check:
     needs: spotless
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,17 @@ name: Gradle Build
 on: [push, pull_request]
 
 jobs:
+  spotless:
+    runs-on: ubuntu-latest
+      name: Spotless Check
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Spotless Check
+          run: ./gradlew spotlessCheck
   check:
+    needs: spotless
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Spotless Check
         run: ./gradlew spotlessCheck
@@ -21,7 +21,7 @@ jobs:
       - name: Publish to Maven Local
         run: |
           ./gradlew publishToMavenLocal
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Runs gradle check only if spotless is successful.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/110

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
