### PR TITLE
Fix TransportService initialization

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -71,7 +71,8 @@ public class ExtensionsRunner {
     /**
      * This field is initialized by a call from {@link ExtensionsInitRequestHandler}.
      */
-    public TransportService extensionTransportService = null;
+    TransportService extensionTransportService = null;
+
     // The routes and classes which handle the REST requests
     private final ExtensionRestPathRegistry extensionRestPathRegistry = new ExtensionRestPathRegistry();
     // Custom settings from the extension's getSettings
@@ -85,7 +86,7 @@ public class ExtensionsRunner {
      */
     public final Settings settings;
     private ExtensionNamedWriteableRegistry namedWriteableRegistry = new ExtensionNamedWriteableRegistry();
-    private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler();
+    private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler(this);
     private OpensearchRequestHandler opensearchRequestHandler = new OpensearchRequestHandler(namedWriteableRegistry);
     private ExtensionsIndicesModuleRequestHandler extensionsIndicesModuleRequestHandler = new ExtensionsIndicesModuleRequestHandler();
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
@@ -188,7 +189,7 @@ public class ExtensionsRunner {
             false,
             false,
             InitializeExtensionsRequest::new,
-            (request, channel, task) -> channel.sendResponse(extensionsInitRequestHandler.handleExtensionInitRequest(request, this))
+            (request, channel, task) -> channel.sendResponse(extensionsInitRequestHandler.handleExtensionInitRequest(request))
         );
 
         transportService.registerRequestHandler(
@@ -441,6 +442,10 @@ public class ExtensionsRunner {
         return settings;
     }
 
+    public TransportService getExtensionTransportService() {
+        return extensionTransportService;
+    }
+
     /**
      * Starts an ActionListener.
      *
@@ -462,7 +467,9 @@ public class ExtensionsRunner {
         ExtensionsRunner runner = new ExtensionsRunner(extension);
         // initialize the transport service
         NettyTransport nettyTransport = new NettyTransport(runner);
-        nettyTransport.initializeExtensionTransportService(runner.getSettings(), new ThreadPool(runner.getSettings()), runner);
+        Settings runnerSettings = runner.getSettings();
+        ThreadPool threadPool = new ThreadPool(runnerSettings);
+        runner.extensionTransportService = nettyTransport.initializeExtensionTransportService(runnerSettings, threadPool);
         runner.startActionListener(0);
     }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -71,7 +71,7 @@ public class ExtensionsRunner {
     /**
      * This field is initialized by a call from {@link ExtensionsInitRequestHandler}.
      */
-    TransportService extensionTransportService = null;
+    private TransportService extensionTransportService = null;
 
     // The routes and classes which handle the REST requests
     private final ExtensionRestPathRegistry extensionRestPathRegistry = new ExtensionRestPathRegistry();

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -100,11 +100,6 @@ public class NettyTransport {
 
         Netty4Transport transport = getNetty4Transport(settings, threadPool);
 
-        // Stop any existing transport service
-        if (extensionsRunner.extensionTransportService != null) {
-            extensionsRunner.extensionTransportService.stop();
-        }
-
         // create transport service
         TransportService transportService = new TransportService(
             settings,

--- a/src/main/java/org/opensearch/sdk/NettyTransport.java
+++ b/src/main/java/org/opensearch/sdk/NettyTransport.java
@@ -94,14 +94,9 @@ public class NettyTransport {
      *
      * @param settings  The transport settings to configure.
      * @param threadPool The thread pool to use to start transport service.
-     * @param extensionsRunner method to call
      * @return The initialized TransportService object.
      */
-    public TransportService initializeExtensionTransportService(
-        Settings settings,
-        ThreadPool threadPool,
-        ExtensionsRunner extensionsRunner
-    ) {
+    public TransportService initializeExtensionTransportService(Settings settings, ThreadPool threadPool) {
 
         Netty4Transport transport = getNetty4Transport(settings, threadPool);
 

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -22,17 +22,23 @@ public class ExtensionsInitRequestHandler {
     private static final Logger logger = LogManager.getLogger(ExtensionsInitRequestHandler.class);
     private static final String NODE_NAME_SETTING = "node.name";
 
+    private final ExtensionsRunner extensionsRunner;
+
+    /**
+     * Instantiate this object with a reference to the ExtensionsRunner
+     * @param extensionsRunner the ExtensionsRunner instance
+     */
+    public ExtensionsInitRequestHandler(ExtensionsRunner extensionsRunner) {
+        this.extensionsRunner = extensionsRunner;
+    }
+
     /**
      * Handles a extension request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
      *
      * @param extensionInitRequest  The request to handle.
-     * @param extensionsRunner The method call from handler.
      * @return A response to OpenSearch validating that this is an extension.
      */
-    public InitializeExtensionsResponse handleExtensionInitRequest(
-        InitializeExtensionsRequest extensionInitRequest,
-        ExtensionsRunner extensionsRunner
-    ) {
+    public InitializeExtensionsResponse handleExtensionInitRequest(InitializeExtensionsRequest extensionInitRequest) {
         logger.info("Registering Extension Request received from OpenSearch");
         extensionsRunner.opensearchNode = extensionInitRequest.getSourceNode();
         extensionsRunner.setUniqueId(extensionInitRequest.getExtension().getId());
@@ -43,11 +49,12 @@ public class ExtensionsInitRequestHandler {
             // After sending successful response to initialization, send the REST API and Settings
             extensionsRunner.setOpensearchNode(extensionsRunner.opensearchNode);
             extensionsRunner.setExtensionNode(extensionInitRequest.getExtension());
-            extensionsRunner.extensionTransportService.connectToNode(extensionsRunner.opensearchNode);
-            extensionsRunner.sendRegisterRestActionsRequest(extensionsRunner.extensionTransportService);
-            extensionsRunner.sendRegisterCustomSettingsRequest(extensionsRunner.extensionTransportService);
+            TransportService extensionTransportService = extensionsRunner.getExtensionTransportService();
+            extensionTransportService.connectToNode(extensionsRunner.opensearchNode);
+            extensionsRunner.sendRegisterRestActionsRequest(extensionTransportService);
+            extensionsRunner.sendRegisterCustomSettingsRequest(extensionTransportService);
             extensionsRunner.transportActions.sendRegisterTransportActionsRequest(
-                extensionsRunner.extensionTransportService,
+                extensionTransportService,
                 extensionsRunner.opensearchNode,
                 extensionsRunner.getUniqueId()
             );

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -69,7 +69,7 @@ import org.opensearch.common.settings.WriteableSetting;
 public class TestExtensionsRunner extends OpenSearchTestCase {
 
     private static final String EXTENSION_NAME = "sample-extension";
-    private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler();
+    private ExtensionsInitRequestHandler extensionsInitRequestHandler;
     private OpensearchRequestHandler opensearchRequestHandler = new OpensearchRequestHandler(new ExtensionNamedWriteableRegistry());
     private ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(new ExtensionRestPathRegistry());
     private ExtensionsRunner extensionsRunner;
@@ -80,6 +80,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.extensionsRunner = new ExtensionsRunnerForTest();
+        this.extensionsInitRequestHandler = new ExtensionsInitRequestHandler(extensionsRunner);
 
         this.transportService = spy(
             new TransportService(
@@ -146,10 +147,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         InitializeExtensionsRequest extensionInitRequest = new InitializeExtensionsRequest(sourceNode, extension);
 
-        InitializeExtensionsResponse response = extensionsInitRequestHandler.handleExtensionInitRequest(
-            extensionInitRequest,
-            extensionsRunner
-        );
+        InitializeExtensionsResponse response = extensionsInitRequestHandler.handleExtensionInitRequest(extensionInitRequest);
         // Test if name and unique ID are set
         assertEquals(EXTENSION_NAME, response.getName());
         assertEquals("opensearch-sdk-1", extensionsRunner.getUniqueId());

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -151,7 +151,7 @@ public class TransportCommunicationIT extends OpenSearchIntegTestCase {
         ExtensionsRunner extensionsRunner = new ExtensionsRunnerForTest();
         // start transport service
         ThreadPool threadPool = new ThreadPool(settings);
-        TransportService transportService = nettyTransport.initializeExtensionTransportService(settings, threadPool, extensionsRunner);
+        TransportService transportService = nettyTransport.initializeExtensionTransportService(settings, threadPool);
 
         assertEquals(Lifecycle.State.STARTED, transportService.lifecycleState());
 


### PR DESCRIPTION
### Description
In the back and forth of #166, and resolving merge conflicts, some changes I thought had been committed ended up backed out. A change to return the intialized transportService from the method that started it was not actually assigned to the ExtensionsRunner variable.

This PR fixes that small bug and does a bit more cleanup/refactoring around the ExtensionsRunner and TransportService.

### Issues Resolved

Relates to #172 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
