### PR TITLE
Enforce type safety for ExtensionNamedWriteableRegistry

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
@@ -100,7 +100,6 @@ public class ExtensionNamedWriteableRegistry {
      * @throws IOException if InputStream generated from the byte array is unsuccessfully closed
      * @return A response acknowledging the request to parse has executed successfully
      */
-    @SuppressWarnings("unchecked")
     public ExtensionBooleanResponse handleNamedWriteableRegistryParseRequest(NamedWriteableRegistryParseRequest request)
         throws IOException {
 
@@ -108,6 +107,7 @@ public class ExtensionNamedWriteableRegistry {
         boolean status = false;
 
         // Extract data from request and procress fully qualified category class name into class instance
+        @SuppressWarnings("unchecked")
         Class<? extends NamedWriteable> categoryClass = request.getCategoryClass();
         byte[] context = request.getContext();
 

--- a/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
@@ -107,7 +107,6 @@ public class ExtensionNamedWriteableRegistry {
         boolean status = false;
 
         // Extract data from request and procress fully qualified category class name into class instance
-        @SuppressWarnings("unchecked")
         Class<? extends NamedWriteable> categoryClass = request.getCategoryClass();
         byte[] context = request.getContext();
 

--- a/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionNamedWriteableRegistry.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.io.stream.InputStreamStreamInput;
+import org.opensearch.common.io.stream.NamedWriteable;
 import org.opensearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.io.stream.NamedWriteableRegistryParseRequest;
@@ -79,12 +80,13 @@ public class ExtensionNamedWriteableRegistry {
      * @param request  The OpenSearch request to handle.
      * @return A response with a list of writeable names and fully qualified category class names to register within OpenSearch
      */
+    @SuppressWarnings("unchecked")
     public NamedWriteableRegistryResponse handleNamedWriteableRegistryRequest(OpenSearchRequest request) {
         logger.info("Registering Named Writeable Registry Request recieved from OpenSearch.");
         // Iterate through Extensions's named writeables and add to extension entries
-        Map<String, Class> extensionEntries = new HashMap<>();
+        Map<String, Class<? extends NamedWriteable>> extensionEntries = new HashMap<>();
         for (NamedWriteableRegistry.Entry entry : this.namedWriteables) {
-            extensionEntries.put(entry.name, entry.categoryClass);
+            extensionEntries.put(entry.name, (Class<? extends NamedWriteable>) entry.categoryClass);
         }
         NamedWriteableRegistryResponse namedWriteableRegistryResponse = new NamedWriteableRegistryResponse(extensionEntries);
         return namedWriteableRegistryResponse;
@@ -98,6 +100,7 @@ public class ExtensionNamedWriteableRegistry {
      * @throws IOException if InputStream generated from the byte array is unsuccessfully closed
      * @return A response acknowledging the request to parse has executed successfully
      */
+    @SuppressWarnings("unchecked")
     public ExtensionBooleanResponse handleNamedWriteableRegistryParseRequest(NamedWriteableRegistryParseRequest request)
         throws IOException {
 
@@ -105,7 +108,7 @@ public class ExtensionNamedWriteableRegistry {
         boolean status = false;
 
         // Extract data from request and procress fully qualified category class name into class instance
-        Class categoryClass = request.getCategoryClass();
+        Class<? extends NamedWriteable> categoryClass = request.getCategoryClass();
         byte[] context = request.getContext();
 
         // Transform byte array context into an input stream

--- a/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
@@ -135,12 +135,12 @@ public class TestNamedWriteableRegistryAPI extends OpenSearchTestCase {
         StreamInput in = new InputStreamStreamInput(input);
 
         // Category Class ExtensionRunner is not registered
-        NamedWriteableRegistryParseRequest request = new NamedWriteableRegistryParseRequest(ExtensionsRunner.class, in);
+        NamedWriteableRegistryParseRequest request = new NamedWriteableRegistryParseRequest(NamedWriteable.class, in);
         Exception e = expectThrows(
             Exception.class,
             () -> extensionNamedWriteableRegistry.handleNamedWriteableRegistryParseRequest(request)
         );
-        assertEquals(e.getMessage(), "Unknown NamedWriteable category [" + ExtensionsRunner.class.getName() + "]");
+        assertEquals(e.getMessage(), "Unknown NamedWriteable category [" + NamedWriteable.class.getName() + "]");
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
Add generic type for `categoryClass` in `ExtensionNamedWriteableRegistry` and `TestNamedWriteableRegistryAPI`
Equivalent PR on OpenSearch: https://github.com/opensearch-project/OpenSearch/pull/4923

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
