### PR TITLE
Move extension settings reading into the BaseExtension

### DIFF
--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -56,7 +56,7 @@ public abstract class BaseExtension implements Extension {
             if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
                 throw new IOException("Failed to initialize Extension settings. No port bound.");
             }
-            this.settings = Extension.readSettingsFromYaml(path);   
+            this.settings = Extension.readSettingsFromYaml(path);
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.sdk;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -35,10 +36,40 @@ public abstract class BaseExtension implements Extension {
     protected ThreadPool threadPool;
 
     /**
-     * Empty constructor to fulfill abstract class requirements
+     * Optional classpath-relative path to a yml file containing extension settings.
+     */
+    protected static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
+
+    /**
+     * The extension settings include a name, host address, and port.
+     */
+    protected ExtensionSettings settings;
+
+    /**
+     * Instantiate this extension, initializing the connection settings and REST actions.
      */
     protected BaseExtension() {
+        try {
+            this.settings = initializeSettings();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
+    /**
+     * The Extension must provide its settings to the ExtensionsRunner.
+     * These may be optionally read from a YAML file on the class path.
+     * Or you may directly instantiate with the ExtensionSettings constructor.
+     *
+     * @return This extension's settings.
+     * @throws IOException on failure to load settings.
+     */
+    protected static ExtensionSettings initializeSettings() throws IOException {
+        ExtensionSettings settings = Extension.readSettingsFromYaml(EXTENSION_SETTINGS_PATH);
+        if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
+            throw new IOException("Failed to initialize Extension settings. No port bound.");
+        }
+        return settings;
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -38,20 +38,12 @@ public abstract class BaseExtension implements Extension {
     /**
      * The extension settings include a name, host address, and port.
      */
-    private ExtensionSettings settings;
-
-    /**
-     * Empty constructor to fulfill abastract class requirement
-     */
-    protected BaseExtension() {
-
-    }
+    private final ExtensionSettings settings;
 
     /**
      * Instantiate this extension, initializing the connection settings and REST actions.
-     * @throws IOException on failure to load settings.
      */
-    protected BaseExtension(String path) throws IOException {
+    protected BaseExtension(String path) {
         try {
             this.settings = Extension.readSettingsFromYaml(path);
             if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
@@ -60,6 +52,13 @@ public abstract class BaseExtension implements Extension {
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }
+    }
+
+    /**
+     * take an ExtensionSettings object and set it directly
+     */
+    protected BaseExtension(ExtensionSettings settings) {
+        this.settings = settings;
     }
 
     @Override

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -36,40 +36,35 @@ public abstract class BaseExtension implements Extension {
     protected ThreadPool threadPool;
 
     /**
-     * Optional classpath-relative path to a yml file containing extension settings.
-     */
-    protected static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
-
-    /**
      * The extension settings include a name, host address, and port.
      */
-    protected ExtensionSettings settings;
+    private ExtensionSettings settings;
+
+    /**
+     * Empty constructor to fulfill abastract class requirement
+     */
+    protected BaseExtension() {
+
+    }
 
     /**
      * Instantiate this extension, initializing the connection settings and REST actions.
+     * @throws IOException on failure to load settings.
      */
-    protected BaseExtension() {
+    protected BaseExtension(String path) throws IOException {
         try {
-            this.settings = initializeSettings();
+            this.settings = Extension.readSettingsFromYaml(path);
+            if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
+                throw new IOException("Failed to initialize Extension settings. No port bound.");
+            }
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }
     }
 
-    /**
-     * The Extension must provide its settings to the ExtensionsRunner.
-     * These may be optionally read from a YAML file on the class path.
-     * Or you may directly instantiate with the ExtensionSettings constructor.
-     *
-     * @return This extension's settings.
-     * @throws IOException on failure to load settings.
-     */
-    protected static ExtensionSettings initializeSettings() throws IOException {
-        ExtensionSettings settings = Extension.readSettingsFromYaml(EXTENSION_SETTINGS_PATH);
-        if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
-            throw new IOException("Failed to initialize Extension settings. No port bound.");
-        }
-        return settings;
+    @Override
+    public ExtensionSettings getExtensionSettings() {
+        return this.settings;
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -53,10 +53,10 @@ public abstract class BaseExtension implements Extension {
      */
     protected BaseExtension(String path) throws IOException {
         try {
-            this.settings = Extension.readSettingsFromYaml(path);
             if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
                 throw new IOException("Failed to initialize Extension settings. No port bound.");
             }
+            this.settings = Extension.readSettingsFromYaml(path);   
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -53,10 +53,10 @@ public abstract class BaseExtension implements Extension {
      */
     protected BaseExtension(String path) throws IOException {
         try {
+            this.settings = Extension.readSettingsFromYaml(path);
             if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
                 throw new IOException("Failed to initialize Extension settings. No port bound.");
             }
-            this.settings = Extension.readSettingsFromYaml(path);
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -31,25 +31,11 @@ import org.opensearch.sdk.sample.helloworld.rest.RestHelloAction;
 public class HelloWorldExtension extends BaseExtension {
 
     /**
-     * Optional classpath-relative path to a yml file containing extension settings.
-     */
-    private static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
-
-    /**
-     * The extension settings include a name, host address, and port.
-     */
-    private ExtensionSettings settings;
-
-    /**
      * Instantiate this extension, initializing the connection settings and REST actions.
      */
     public HelloWorldExtension() {
         super();
-        try {
-            this.settings = initializeSettings();
-        } catch (IOException e) {
-            throw new ExceptionInInitializerError(e);
-        }
+
     }
 
     @Override
@@ -60,22 +46,6 @@ public class HelloWorldExtension extends BaseExtension {
     @Override
     public List<ExtensionRestHandler> getExtensionRestHandlers() {
         return List.of(new RestHelloAction());
-    }
-
-    /**
-     * The Extension must provide its settings to the ExtensionsRunner.
-     * These may be optionally read from a YAML file on the class path.
-     * Or you may directly instantiate with the ExtensionSettings constructor.
-     *
-     * @return This extension's settings.
-     * @throws IOException on failure to load settings.
-     */
-    private static ExtensionSettings initializeSettings() throws IOException {
-        ExtensionSettings settings = Extension.readSettingsFromYaml(EXTENSION_SETTINGS_PATH);
-        if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
-            throw new IOException("Failed to initialize Extension settings. No port bound.");
-        }
-        return settings;
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -36,14 +36,13 @@ public class HelloWorldExtension extends BaseExtension {
     private static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
 
     /**
-     *
+     * Instantiate this extension, initializing the connection settings and REST actions.
      * The Extension must provide its settings to the ExtensionsRunner.
      * These may be optionally read from a YAML file on the class path.
      * Or you may directly instantiate with the ExtensionSettings constructor.
      *
-     * @throws IOException on failure to load settings.
      */
-    public HelloWorldExtension() throws IOException {
+    public HelloWorldExtension() {
         super(EXTENSION_SETTINGS_PATH);
     }
 

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -31,16 +31,20 @@ import org.opensearch.sdk.sample.helloworld.rest.RestHelloAction;
 public class HelloWorldExtension extends BaseExtension {
 
     /**
-     * Instantiate this extension, initializing the connection settings and REST actions.
+     * Optional classpath-relative path to a yml file containing extension settings.
      */
-    public HelloWorldExtension() {
-        super();
+    private static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
 
-    }
-
-    @Override
-    public ExtensionSettings getExtensionSettings() {
-        return this.settings;
+    /**
+     *
+     * The Extension must provide its settings to the ExtensionsRunner.
+     * These may be optionally read from a YAML file on the class path.
+     * Or you may directly instantiate with the ExtensionSettings constructor.
+     *
+     * @throws IOException on failure to load settings.
+     */
+    public HelloWorldExtension() throws IOException {
+        super(EXTENSION_SETTINGS_PATH);
     }
 
     @Override

--- a/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
+++ b/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
@@ -15,11 +15,7 @@ public class ExtensionsRunnerForTest extends ExtensionsRunner {
      * @throws IOException if the runner failed to read settings or API.
      */
     public ExtensionsRunnerForTest() throws IOException {
-        super(new BaseExtension() {
-            @Override
-            public ExtensionSettings getExtensionSettings() {
-                return new ExtensionSettings("sample-extension", "127.0.0.1", "4532");
-            }
+        super(new BaseExtension(new ExtensionSettings("sample-extension", "127.0.0.1", "4532")) {
 
             @Override
             public List<ExtensionRestHandler> getExtensionRestHandlers() {


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
Move the `extensionSettings` field and the initialization in the constructor and all the exception handling in `HelloWorldExtension` to `BaseExtension`.

### Issues Resolved
Fixes #182

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
