### PR TITLE
Migrate client transports to Apache HttpClient/Core5.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,16 @@ configurations {
 }
 
 dependencies {
-    implementation "org.opensearch:opensearch:3.0.0-SNAPSHOT"
-    implementation "org.opensearch.plugin:transport-netty4-client:3.0.0-SNAPSHOT"
+
+    def jacksonDatabindVersion = "2.12.6.1"
+    def opensearchVersion = "3.0.0-SNAPSHOT"
+
+    implementation("org.opensearch:opensearch:${opensearchVersion}")
+    implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
-    implementation 'org.opensearch.client:opensearch-rest-client:3.0.0-SNAPSHOT'
-    implementation 'org.opensearch.client:opensearch-java:3.0.0-SNAPSHOT'
+    implementation("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
+    implementation("org.opensearch.client:opensearch-java:${opensearchVersion}")
     implementation "io.netty:netty-all:4.1.73.Final"
     implementation "org.apache.lucene:lucene-core:9.4.0-snapshot-ddf0d0a"
     testCompileOnly ("junit:junit:4.13.2") {
@@ -74,12 +78,12 @@ dependencies {
         exclude module : 'hamcrest-core'
     }
     implementation 'javax.xml.bind:jaxb-api:2.2.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind: 2.12.6.1'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml: 2.12.6.1'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.6.1'
+    implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonDatabindVersion}")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonDatabindVersion}")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testImplementation "org.opensearch.test:framework:3.0.0-SNAPSHOT"
+    testImplementation("org.opensearch.test:framework:${opensearchVersion}")
     requireJavadoc "org.plumelib:require-javadoc:1.0.4"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,8 @@ dependencies {
     implementation "org.opensearch.plugin:transport-netty4-client:3.0.0-SNAPSHOT"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
-    implementation 'org.opensearch.client:opensearch-rest-client:2.0.0'
-    implementation 'org.opensearch.client:opensearch-java:2.0.0'
+    implementation 'org.opensearch.client:opensearch-rest-client:3.0.0-SNAPSHOT'
+    implementation 'org.opensearch.client:opensearch-java:3.0.0-SNAPSHOT'
     implementation "io.netty:netty-all:4.1.73.Final"
     implementation "org.apache.lucene:lucene-core:9.4.0-snapshot-ddf0d0a"
     testCompileOnly ("junit:junit:4.13.2") {
@@ -76,6 +76,7 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.2.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind: 2.12.6.1'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml: 2.12.6.1'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310: 2.12.6.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation "org.opensearch.test:framework:3.0.0-SNAPSHOT"

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -11,14 +11,25 @@ package org.opensearch.sdk;
 
 import java.io.IOException;
 
-import org.apache.http.HttpHost;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.hc.core5.function.Factory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
+
+import javax.net.ssl.SSLEngine;
 
 /**
  * This class creates SDKClient for an extension to make requests to OpenSearch
@@ -35,11 +46,27 @@ public class SDKClient {
      * @return SDKClient which is internally an OpenSearchClient. The user is responsible for calling {@link #doCloseRestClient()} when finished with the client
      */
     public OpenSearchClient initializeClient(String hostAddress, int port) throws IOException {
-        RestClientBuilder builder = RestClient.builder(new HttpHost(hostAddress, port));
+        RestClientBuilder builder = RestClient.builder(new HttpHost("http", hostAddress, port));
         builder.setStrictDeprecationMode(true);
         builder.setHttpClientConfigCallback(httpClientBuilder -> {
             try {
-                return httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+                final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+                    .setSslContext(SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build())
+                    // disable the certificate since our testing cluster just uses the default security configuration
+                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
+                    .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
+                        @Override
+                        public TlsDetails create(final SSLEngine sslEngine) {
+                            return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
+                        }
+                    })
+                    .build();
+
+                final PoolingAsyncClientConnectionManager connectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setTlsStrategy(tlsStrategy)
+                    .build();
+                return httpClientBuilder.setConnectionManager(connectionManager);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -48,7 +75,10 @@ public class SDKClient {
         restClient = builder.build();
 
         // Create Client
-        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        OpenSearchTransport transport = new RestClientTransport(
+            restClient,
+            new JacksonJsonpMapper(new ObjectMapper().registerModule(new JavaTimeModule()))
+        );
         javaClient = new OpenSearchClient(transport);
         return javaClient;
     }

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -46,7 +46,7 @@ public class SDKClient {
      * @return SDKClient which is internally an OpenSearchClient. The user is responsible for calling {@link #doCloseRestClient()} when finished with the client
      */
     public OpenSearchClient initializeClient(String hostAddress, int port) throws IOException {
-        RestClientBuilder builder = RestClient.builder(new HttpHost("http", hostAddress, port));
+        RestClientBuilder builder = RestClient.builder(new HttpHost(hostAddress, port));
         builder.setStrictDeprecationMode(true);
         builder.setHttpClientConfigCallback(httpClientBuilder -> {
             try {

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -52,7 +52,7 @@ public class SDKClient {
             try {
                 final TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
                     .setSslContext(SSLContextBuilder.create().loadTrustMaterial(null, (chains, authType) -> true).build())
-                    // disable the certificate since our testing cluster just uses the default security configuration
+                    // disable the certificate since our cluster currently just uses the default security configuration
                     .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                     // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
                     .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {

--- a/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
@@ -68,6 +68,8 @@ public class ClusterStateResponseHandler implements TransportResponseHandler<Clu
 
     /**
      * Invokes await on the ClusterStateResponseHandler count down latch
+     * @throws InterruptedException
+     *     if await returns an exception
      */
     public void awaitResponse() throws InterruptedException {
         inProgressLatch.await(ExtensionsOrchestrator.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
@@ -69,7 +69,7 @@ public class ClusterStateResponseHandler implements TransportResponseHandler<Clu
     /**
      * Invokes await on the ClusterStateResponseHandler count down latch
      * @throws InterruptedException
-     *     if await returns an exception
+     *     if the response times out
      */
     public void awaitResponse() throws InterruptedException {
         inProgressLatch.await(ExtensionsOrchestrator.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
@@ -69,7 +69,7 @@ public class EnvironmentSettingsResponseHandler implements TransportResponseHand
     /**
      * Invokes await on the EnvironmentSettingsResponseHandler count down latch
      * @throws InterruptedException
-     *        if await returns an exception
+     *        if the response times out
      */
     public void awaitResponse() throws InterruptedException {
         inProgressLatch.await(ExtensionsOrchestrator.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
@@ -68,6 +68,8 @@ public class EnvironmentSettingsResponseHandler implements TransportResponseHand
 
     /**
      * Invokes await on the EnvironmentSettingsResponseHandler count down latch
+     * @throws InterruptedException
+     *        if await returns an exception
      */
     public void awaitResponse() throws InterruptedException {
         inProgressLatch.await(ExtensionsOrchestrator.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
This PR covers:
1. Migrate client transports to Apache HttpClient / Core 5.x - https://github.com/opensearch-project/opensearch-java/pull/246
2. Support Java 8 Time (JSR 310) objects https://github.com/opensearch-project/opensearch-java/issues/250

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-sdk-java/issues/210

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
