### PR TITLE
Prevent duplicate workflow runs on dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
 name: Gradle Build
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   spotless:

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,5 +1,10 @@
 name: Validate Gradle Wrapper
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   validate:


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Ignores pushes to branches starting with `dependabot`, as these branches are used to submit pull requests and cause duplicate workflow runs.

### Issues Resolved
Fixes #230 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
