### PR TITLE
 Provide a higher level implementation for REST handlers 

### DIFF
--- a/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import static org.opensearch.rest.RestStatus.NOT_FOUND;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.xcontent.XContentBuilder;
+import org.opensearch.extensions.rest.ExtensionRestRequest;
+import org.opensearch.extensions.rest.ExtensionRestResponse;
+import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.rest.RestStatus;
+
+/**
+ * Provides convenience methods to reduce boilerplate code in an {@link ExtensionRestHandler} implementation.
+ */
+public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
+
+    private ExtensionRestRequest request;
+
+    /**
+     * Defines a list of methods which handle each rest {@link Route}.
+     *
+     * @return a list of {@link RouteHandler} with corresponding methods to each route.
+     */
+    protected abstract List<RouteHandler> routeHandlers();
+
+    @Override
+    public List<Route> routes() {
+        return List.copyOf(routeHandlers());
+    }
+
+    @Override
+    public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
+        this.request = request;
+        Optional<RouteHandler> handler = routeHandlers().stream()
+            .filter(rh -> rh.getMethod().equals(request.method()))
+            .filter(rh -> restPathMatches(request.path(), rh.getPath()))
+            .findFirst();
+        return handler.isPresent() ? handler.get().getExtensionRestResponse() : unhandledRequest();
+    }
+
+    /**
+     * Determines if the request's path is a match for the configured handler path.
+     *
+     * @param requestPath The path from the {@link ExtensionRestRequest}
+     * @param handlerPath The path from the {@link RouteHandler}
+     * @return true if the request path matches the route
+     */
+    private boolean restPathMatches(String requestPath, String handlerPath) {
+        // Check exact match
+        if (handlerPath.equals(requestPath)) {
+            return true;
+        }
+        // Split path to evaluate named params
+        String[] handlerSplit = handlerPath.split("/");
+        String[] requestSplit = requestPath.split("/");
+        if (handlerSplit.length != requestSplit.length) {
+            return false;
+        }
+        for (int i = 0; i < handlerSplit.length; i++) {
+            if (!(handlerSplit[i].equals(requestSplit[i]) || (handlerSplit[i].startsWith("{") && handlerSplit[i].endsWith("}")))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns a default response when a request does not match the handled methods or paths. This can occur if a
+     * handler indicates routes that it handles but does not actually handle them.
+     *
+     * @return an ExtensionRestResponse identifying the unhandled request.
+     */
+    protected ExtensionRestResponse unhandledRequest() {
+        return createResponse(NOT_FOUND, "Extension REST action improperly configured to handle " + getRequest().toString());
+    }
+
+    /**
+     * Creates an {@link ExtensionRestResponse} with the given status and Xcontent.
+     *
+     * @param status The {@link RestStatus} for the response.
+     * @param builder An {@link XContentBuilder} for the response.
+     * @return the response.
+     */
+    protected ExtensionRestResponse createResponse(RestStatus status, XContentBuilder builder) {
+        return new ExtensionRestResponse(getRequest(), status, builder);
+    }
+
+    /**
+     * Creates an {@link ExtensionRestResponse} with the given status and text content.
+     *
+     * @param status The {@link RestStatus} for the response.
+     * @param content The content.
+     * @return the response.
+     */
+    protected ExtensionRestResponse createResponse(RestStatus status, String content) {
+        return new ExtensionRestResponse(getRequest(), status, content);
+    }
+
+    /**
+     * Creates an {@link ExtensionRestResponse} with the given status and content.
+     *
+     * @param status The {@link RestStatus} for the response.
+     * @param contentType The type of the content.
+     * @param content The content.
+     * @return the response.
+     */
+    protected ExtensionRestResponse createResponse(RestStatus status, String contentType, String content) {
+        return new ExtensionRestResponse(getRequest(), status, contentType, content);
+    }
+
+    /**
+     * Creates an {@link ExtensionRestResponse} with the given status and binary content.
+     *
+     * @param status The {@link RestStatus} for the response.
+     * @param contentType The type of the content.
+     * @param content The content.
+     * @return the response.
+     */
+    protected ExtensionRestResponse createResponse(RestStatus status, String contentType, byte[] content) {
+        return new ExtensionRestResponse(getRequest(), status, contentType, content);
+    }
+
+    /**
+     * Creates an {@link ExtensionRestResponse} with the given status and binary content.
+     *
+     * @param status The {@link RestStatus} for the response.
+     * @param contentType The type of the content.
+     * @param content The content.
+     * @return the response.
+     */
+    protected ExtensionRestResponse createResponse(RestStatus status, String contentType, BytesReference content) {
+        return new ExtensionRestResponse(getRequest(), status, contentType, content);
+    }
+
+    public ExtensionRestRequest getRequest() {
+        return request;
+    }
+}

--- a/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 
 import static org.opensearch.rest.RestStatus.NOT_FOUND;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,10 +26,13 @@ public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
 
     /**
      * Defines a list of methods which handle each rest {@link Route}.
+     * Override this in a subclass to use the functional syntax.
      *
      * @return a list of {@link RouteHandler} with corresponding methods to each route.
      */
-    protected abstract List<RouteHandler> routeHandlers();
+    protected List<RouteHandler> routeHandlers() {
+        return Collections.emptyList();
+    }
 
     @Override
     public List<Route> routes() {

--- a/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionRestHandler.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.sdk;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.opensearch.extensions.rest.ExtensionRestRequest;
@@ -22,14 +23,8 @@ import org.opensearch.rest.RestRequest;
  * This interface defines methods which an extension REST handler (action) must provide.
  * It is the Extension counterpart to core OpenSearch {@link RestHandler}.
  */
+@FunctionalInterface
 public interface ExtensionRestHandler {
-
-    /**
-     * The list of {@link Route}s that this ExtensionRestHandler is responsible for handling.
-     *
-     * @return The routes this handler will handle.
-     */
-    List<Route> routes();
 
     /**
      * Handles REST Requests forwarded from OpenSearch for a configured route on an extension.
@@ -40,4 +35,13 @@ public interface ExtensionRestHandler {
      * @return An {@link ExtensionRestResponse} to the request.
      */
     ExtensionRestResponse handleRequest(ExtensionRestRequest request);
+
+    /**
+     * A list of {@link Route}s that this ExtensionRestHandler is responsible for handling.
+     *
+     * @return The routes this handler will handle.
+     */
+    default List<Route> routes() {
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/org/opensearch/sdk/RouteHandler.java
+++ b/src/main/java/org/opensearch/sdk/RouteHandler.java
@@ -9,8 +9,9 @@
 
 package org.opensearch.sdk;
 
-import java.util.function.Supplier;
+import java.util.function.Function;
 
+import org.opensearch.extensions.rest.ExtensionRestRequest;
 import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest.Method;
@@ -20,7 +21,7 @@ import org.opensearch.rest.RestRequest.Method;
  */
 public class RouteHandler extends Route {
 
-    private final Supplier<ExtensionRestResponse> responseHandler;
+    private final Function<ExtensionRestRequest, ExtensionRestResponse> responseHandler;
 
     /**
      * Handle the method and path with the specified handler.
@@ -29,7 +30,7 @@ public class RouteHandler extends Route {
      * @param path The path to handle.
      * @param handler The method which handles the method and path.
      */
-    public RouteHandler(Method method, String path, Supplier<ExtensionRestResponse> handler) {
+    public RouteHandler(Method method, String path, Function<ExtensionRestRequest, ExtensionRestResponse> handler) {
         super(method, path);
         this.responseHandler = handler;
     }
@@ -37,9 +38,10 @@ public class RouteHandler extends Route {
     /**
      * Executes the handler for this route.
      *
+     * @param request The request to handle
      * @return the {@link ExtensionRestResponse} result from the handler for this route.
      */
-    public ExtensionRestResponse getExtensionRestResponse() {
-        return responseHandler.get();
+    public ExtensionRestResponse handleRequest(ExtensionRestRequest request) {
+        return responseHandler.apply(request);
     }
 }

--- a/src/main/java/org/opensearch/sdk/RouteHandler.java
+++ b/src/main/java/org/opensearch/sdk/RouteHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import java.util.function.Supplier;
+
+import org.opensearch.extensions.rest.ExtensionRestResponse;
+import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.rest.RestRequest.Method;
+
+/**
+ * A subclass of {@link Route} that includes a handler method for that route.
+ */
+public class RouteHandler extends Route {
+
+    private final Supplier<ExtensionRestResponse> responseHandler;
+
+    /**
+     * Handle the method and path with the specified handler.
+     *
+     * @param method The {@link Method} to handle.
+     * @param path The path to handle.
+     * @param handler The method which handles the method and path.
+     */
+    public RouteHandler(Method method, String path, Supplier<ExtensionRestResponse> handler) {
+        super(method, path);
+        this.responseHandler = handler;
+    }
+
+    /**
+     * Executes the handler for this route.
+     *
+     * @return the {@link ExtensionRestResponse} result from the handler for this route.
+     */
+    public ExtensionRestResponse getExtensionRestResponse() {
+        return responseHandler.get();
+    }
+}

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/rest/RestHelloAction.java
@@ -45,7 +45,7 @@ import static org.opensearch.rest.RestStatus.OK;
  */
 public class RestHelloAction extends BaseExtensionRestHandler {
 
-    private static final String TEXT_CONTENT_TYPE = "text/plain;charset=UTF-8";
+    private static final String TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8";
     private static final String GREETING = "Hello, %s!";
     private static final String DEFAULT_NAME = "World";
 

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
@@ -23,13 +23,15 @@ import org.opensearch.common.bytes.BytesArray;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
-import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestResponse;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class TestRestHelloAction extends OpenSearchTestCase {
+
+    private static final String TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8";
+    private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
     private ExtensionRestHandler restHelloAction;
     private static final String EXTENSION_NAME = "hello-world";
@@ -93,60 +95,60 @@ public class TestRestHelloAction extends OpenSearchTestCase {
         // Initial default response
         RestResponse response = restHelloAction.handleRequest(getRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         String responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Hello, World!", responseStr);
 
         // Change world's name
         response = restHelloAction.handleRequest(putRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Updated the world's name to Passing Test", responseStr);
 
         response = restHelloAction.handleRequest(getRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Hello, Passing Test!", responseStr);
 
         // Add an adjective
         response = restHelloAction.handleRequest(postRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(JSON_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("testable"));
 
         response = restHelloAction.handleRequest(getRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Hello, testable Passing Test!", responseStr);
 
         // Remove the name and adjective
         response = restHelloAction.handleRequest(deleteRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("Goodbye, cruel world!"));
 
         response = restHelloAction.handleRequest(getRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Hello, World!", responseStr);
 
         // Unparseable
         response = restHelloAction.handleRequest(badRequest);
         assertEquals(RestStatus.BAD_REQUEST, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("Illegal hex characters in escape (%) pattern"));
 
         // Not registered
         response = restHelloAction.handleRequest(unhandledRequest);
         assertEquals(RestStatus.NOT_FOUND, response.status());
-        assertEquals(BytesRestResponse.TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("/hi"));
     }

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
@@ -81,6 +81,30 @@ public class TestRestHelloAction extends OpenSearchTestCase {
             new BytesArray("{\"adjective\":\"testable\"}"),
             token
         );
+        ExtensionRestRequest badPostRequest = new ExtensionRestRequest(
+            Method.POST,
+            "/hello",
+            params,
+            XContentType.JSON,
+            new BytesArray("{\"adjective\":\"\"}"),
+            token
+        );
+        ExtensionRestRequest noContentPostRequest = new ExtensionRestRequest(
+            Method.POST,
+            "/hello",
+            params,
+            null,
+            new BytesArray(""),
+            token
+        );
+        ExtensionRestRequest badContentTypePostRequest = new ExtensionRestRequest(
+            Method.POST,
+            "/hello",
+            params,
+            XContentType.YAML,
+            new BytesArray("yaml:"),
+            token
+        );
         ExtensionRestRequest deleteRequest = new ExtensionRestRequest(Method.DELETE, "/goodbye", params, null, new BytesArray(""), token);
         ExtensionRestRequest badRequest = new ExtensionRestRequest(
             Method.PUT,
@@ -90,7 +114,16 @@ public class TestRestHelloAction extends OpenSearchTestCase {
             new BytesArray(""),
             token
         );
-        ExtensionRestRequest unhandledRequest = new ExtensionRestRequest(Method.HEAD, "/hi", params, null, new BytesArray(""), token);
+        ExtensionRestRequest unhandledMethodRequest = new ExtensionRestRequest(Method.HEAD, "/hi", params, null, new BytesArray(""), token);
+        ExtensionRestRequest unhandledPathRequest = new ExtensionRestRequest(Method.GET, "/hi", params, null, new BytesArray(""), token);
+        ExtensionRestRequest unhandledPathLengthRequest = new ExtensionRestRequest(
+            Method.DELETE,
+            "/goodbye/cruel/world",
+            params,
+            null,
+            new BytesArray(""),
+            token
+        );
 
         // Initial default response
         RestResponse response = restHelloAction.handleRequest(getRequest);
@@ -125,6 +158,27 @@ public class TestRestHelloAction extends OpenSearchTestCase {
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertEquals("Hello, testable Passing Test!", responseStr);
 
+        // Try to add a blank adjective
+        response = restHelloAction.handleRequest(badPostRequest);
+        assertEquals(RestStatus.BAD_REQUEST, response.status());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertEquals("No adjective included with POST request", responseStr);
+
+        // Try to add no content
+        response = restHelloAction.handleRequest(noContentPostRequest);
+        assertEquals(RestStatus.BAD_REQUEST, response.status());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertEquals("No content included with POST request", responseStr);
+
+        // Try to add bad content type
+        response = restHelloAction.handleRequest(badContentTypePostRequest);
+        assertEquals(RestStatus.NOT_ACCEPTABLE, response.status());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertEquals("Only text and JSON content types are supported", responseStr);
+
         // Remove the name and adjective
         response = restHelloAction.handleRequest(deleteRequest);
         assertEquals(RestStatus.OK, response.status());
@@ -145,11 +199,25 @@ public class TestRestHelloAction extends OpenSearchTestCase {
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("Illegal hex characters in escape (%) pattern"));
 
-        // Not registered
-        response = restHelloAction.handleRequest(unhandledRequest);
+        // Not registered, fails on method
+        response = restHelloAction.handleRequest(unhandledMethodRequest);
         assertEquals(RestStatus.NOT_FOUND, response.status());
         assertEquals(TEXT_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("/hi"));
+
+        // Not registered, fails on path name
+        response = restHelloAction.handleRequest(unhandledPathRequest);
+        assertEquals(RestStatus.NOT_FOUND, response.status());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertTrue(responseStr.contains("/hi"));
+
+        // Not registered, fails on path length
+        response = restHelloAction.handleRequest(unhandledPathLengthRequest);
+        assertEquals(RestStatus.NOT_FOUND, response.status());
+        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
+        assertTrue(responseStr.contains("/goodbye"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Creates a `RouteHandler` class extending `Route` which also includes a handler method

Creates a `BaseExtensionRestHandler` abstract class:
 - Matches the request's route to its handler
 - Moves the unhandled request boilerplate into the superclass

Note to reviewers: consider [this comment](https://github.com/opensearch-project/opensearch-sdk-java/issues/128#issuecomment-1312656871) for two possible implementations. Happy to switch back to the other one if you don't like the one I chose.  The actual implementation permits either choice; the question is more about what we want the HelloWorld sample to show.

### Issues Resolved

Fixes #128
Fixes #245

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
