### PR TITLE
Configure spotless license header for test classes

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -31,7 +31,7 @@ allprojects {
         }
         format("license", {
             licenseHeaderFile("${rootProject.file("formatter/license-header.txt")}", "package ");
-            target("src/main/java/**/*.java")
+            target("src/*/java/**/*.java")
         })
     }
 }

--- a/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
+++ b/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.sdk;
 
 import java.io.IOException;

--- a/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.sdk;
 
 import java.util.List;

--- a/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.sdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/org/opensearch/sdk/TestExtensionTransportActionsAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionTransportActionsAPI.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
 package org.opensearch.sdk;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -1,12 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.sdk;

--- a/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
+++ b/src/test/java/org/opensearch/sdk/TestNamedWriteableRegistryAPI.java
@@ -1,12 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.sdk;

--- a/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
+++ b/src/test/java/org/opensearch/sdk/TestNetty4Transport.java
@@ -1,12 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.sdk;

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/sdk/TestThreadPool.java
+++ b/src/test/java/org/opensearch/sdk/TestThreadPool.java
@@ -1,12 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.sdk;

--- a/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
+++ b/src/test/java/org/opensearch/sdk/TransportCommunicationIT.java
@@ -1,12 +1,10 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.sdk;

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -1,10 +1,12 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
+
 package org.opensearch.sdk.sample.helloworld;
 
 import java.util.List;

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
@@ -1,10 +1,12 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
+
 package org.opensearch.sdk.sample.helloworld.rest;
 
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
### Description

Changes target from `src/main/java` to `src/*/java` to include test classes.

### Issues Resolved

Fixes #243 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
