### PR TITLE
Add gradle diffCoverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+        with:
+          # needed for git diff to find main branch
+          fetch-depth: "0"
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   check:
@@ -27,6 +29,9 @@ jobs:
         run: |
           ./gradlew publishToMavenLocal
       - uses: actions/checkout@v3
+        with:
+          # needed for git diff to find main branch
+          fetch-depth: "0"
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,14 @@
-- [Contributing to OpenSearch-SDK-Java](#contributing-to-opensearch-sdk-java)
+- [Contributing to OpenSearch SDK for Java](#contributing-to-opensearch-sdk-for-java)
   - [First Things First](#first-things-first)
   - [Ways to Contribute](#ways-to-contribute)
     - [Bug Reports](#bug-reports)
     - [Feature Requests](#feature-requests)
     - [Contributing Code](#contributing-code)
   - [Developer Certificate of Origin](#developer-certificate-of-origin)
+  - [Code Coverage](#code-coverage)
   - [Review Process](#review-process)
 
-# Contributing to OpenSearch-SDK
+# Contributing to OpenSearch SDK for Java
 
 OpenSearch-SDK is a community project that is built and maintained by people just like **you**. We're glad you're interested in helping out. There are several different ways you can do it, but before we talk about that, let's talk about how to get started.
 
@@ -76,6 +77,12 @@ Each commit must include a DCO which looks like this
 Signed-off-by: Jane Smith <jane.smith@email.com>
 ```
 You may type this line on your own when writing your commit messages. However, if your user.name and user.email are set in your git configs, you can use `-s` or `--signoff` to add the `Signed-off-by` line to the end of the commit message.
+
+## Code Coverage
+
+Any new functionality requires testing. Your PR will trigger an automatic assessment of the code coverage of the lines you've added. You should add unit and/or integration tests to exercise as much of your new code as possible.
+
+If you'd like to preview your coverage before submitting your PR, to identify lines of code which are not tested, you may run `./gradlew diffCoverage` and review the report available in the project build directory at `build/reports/jacoco/diffCoverage/html/index.html`.
 
 ## Review Process
 

--- a/build.gradle
+++ b/build.gradle
@@ -168,8 +168,8 @@ diffCoverageReport {
     }
 
     violationRules {
-        minBranches = 0.9
-        minLines = 0.9
-        minInstructions = 0.9
+        minBranches = 0.60
+        minLines = 0.75
+        failOnViolation = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
     id 'java'
     id "com.diffplug.spotless" version "6.11.0" apply false
     id 'jacoco'
+    id "com.form.diff-coverage" version "0.9.5"
 }
 
 
@@ -145,5 +146,30 @@ jacocoTestReport {
     dependsOn test
     reports {
         xml.required = true
+    }
+}
+
+diffCoverageReport {
+    diffSource { // Only one source may be specified
+        // This requires files to have been committed
+        // https://github.com/form-com/diff-coverage-gradle/issues/73
+        git.compareWith 'refs/remotes/origin/main'
+
+        // To compare uncommitted files, uncomment the below:
+        // file = 'build/tmp/git.diff'
+        // And then run:
+        //   git diff refs/remotes/origin/main > build/tmp/git.diff
+        //   ./gradlew diffCoverage
+    }
+
+    // View report at build/reports/jacoco/diffCoverage/html/index.html
+    reports {
+        html = true
+    }
+
+    violationRules {
+        minBranches = 0.9
+        minLines = 0.9
+        minInstructions = 0.9
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@
  * GitHub history for details.
  */
 
+import java.nio.file.Files
+
 plugins {
     id 'java'
     id "com.diffplug.spotless" version "6.11.0" apply false
@@ -149,17 +151,26 @@ jacocoTestReport {
     }
 }
 
-diffCoverageReport {
-    diffSource { // Only one source may be specified
-        // This requires files to have been committed
-        // https://github.com/form-com/diff-coverage-gradle/issues/73
-        git.compareWith 'refs/remotes/origin/main'
+// Get uncommitted files via git diff
+// https://github.com/form-com/diff-coverage-gradle/issues/73
+ext.createDiffFile = { ->
+    def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
+    def diffBase = 'refs/remotes/origin/main'
+    if (System.getenv('CI')) {
+        diffBase = 'origin/' + System.getenv('GITHUB_BASE_REF')
+    }
+    file.withOutputStream { out ->
+        exec {
+            commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
+            standardOutput = out
+        }
+    }
+    return file
+}
 
-        // To compare uncommitted files, uncomment the below:
-        // file = 'build/tmp/git.diff'
-        // And then run:
-        //   git diff refs/remotes/origin/main > build/tmp/git.diff
-        //   ./gradlew diffCoverage
+diffCoverageReport {
+    afterEvaluate {
+        diffSource.file = createDiffFile()
     }
 
     // View report at build/reports/jacoco/diffCoverage/html/index.html


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Adds the [Diff coverage gradle plugin](https://github.com/form-com/diff-coverage-gradle).

Developers can run `./gradlew diffCoverage` which will generate a jacoco coverage report only on the diff from `main`.
 - Keep your github fork `main` synced with upstream for this to work well! You can do it on Github with one click.
 - Due to [a bug](https://github.com/form-com/diff-coverage-gradle/issues/67) you should already have run `./gradle test` or `./gradlew check` or `./gradlew jacocoReport`. This may be fixed by 1.0.0 eventually.
 - Full results are viewable at `build/reports/jacoco/diffCoverage/html/index.html`

See #250 for a discussion on thresholds and including this in CI.

### Issues Resolved
Fixes #129 

Note #129 also mentions updating the `codecov` report on pushes. This is actually already occurring with the default configuration: you can see "edited" on the original report and view changes over time if desired.  (It's possible to configure to get a new report each push, but I prefer the edit/update default.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
