### PR TITLE
Fix diffCoverage GHA on non-PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,9 +155,16 @@ jacocoTestReport {
 // https://github.com/form-com/diff-coverage-gradle/issues/73
 ext.createDiffFile = { ->
     def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
+    // ref for local runs
     def diffBase = 'refs/remotes/origin/main'
     if (System.getenv('CI')) {
-        diffBase = 'origin/' + System.getenv('GITHUB_BASE_REF')
+        if (System.getenv('GITHUB_BASE_REF')) {
+            // we are on a PR
+            diffBase = 'origin/' + System.getenv('GITHUB_BASE_REF')
+        } else {
+            // we are on main branch, no diff
+            diffBase = 'HEAD'
+        }
     }
     file.withOutputStream { out ->
         exec {


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

PR #248 used an environment variable only present on PRs. While the PR passed, it fails on main now.  This should fix main.

### Issues Resolved

Fixes main broken by #248.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
