### PR TITLE
Refactor readSettingsFromYaml to ExtensionSettings

### DIFF
--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -45,7 +45,7 @@ public abstract class BaseExtension implements Extension {
      */
     protected BaseExtension(String path) {
         try {
-            this.settings = Extension.readSettingsFromYaml(path);
+            this.settings = ExtensionSettings.readSettingsFromYaml(path);
             if (settings == null || settings.getHostAddress() == null || settings.getHostPort() == null) {
                 throw new IOException("Failed to initialize Extension settings. No port bound.");
             }

--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -9,9 +9,6 @@
 
 package org.opensearch.sdk;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
 import java.util.Collections;
 import java.util.Collection;
 import java.util.List;
@@ -24,9 +21,6 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.common.settings.Setting;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
  * This interface defines methods which an extension must provide. Extensions
@@ -75,29 +69,5 @@ public interface Extension {
      */
     default Map<String, Class<? extends TransportAction<ActionRequest, ActionResponse>>> getActions() {
         return Collections.emptyMap();
-    }
-
-    /**
-     * Helper method to read extension settings from a YAML file.
-     *
-     * @param extensionSettingsPath
-     *            The path (relative to the classpath) of the extension settings
-     *            file.
-     * @return A settings file encapsulating the extension host and port if the file
-     *         exists, null otherwise.
-     * @throws IOException
-     *             if there is an error reading the file.
-     */
-    static ExtensionSettings readSettingsFromYaml(String extensionSettingsPath) throws IOException {
-        URL resource = Extension.class.getResource(extensionSettingsPath);
-        if (resource == null) {
-            return null;
-        }
-        File file = new File(resource.getPath());
-        if (!file.exists()) {
-            return null;
-        }
-        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-        return objectMapper.readValue(file, ExtensionSettings.class);
     }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -9,6 +9,13 @@
 
 package org.opensearch.sdk;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
 /**
  * This class encapsulates the settings for an Extension.
  */
@@ -21,7 +28,7 @@ public class ExtensionSettings {
     private String opensearchPort;
 
     /**
-     * Jackson requires a default constructor.
+     * Jackson requires a no-arg constructor.
      */
     @SuppressWarnings("unused")
     private ExtensionSettings() {
@@ -34,6 +41,8 @@ public class ExtensionSettings {
      * @param extensionName  The extension name. Provided to OpenSearch as a response to initialization query. Must match the defined extension name in OpenSearch.
      * @param hostAddress  The IP Address to bind this extension to.
      * @param hostPort  The port to bind this extension to.
+     * @param opensearchAddress  The IP Address on which OpenSearch is running.
+     * @param opensearchPort  The port on which OpenSearch is running.
      */
     public ExtensionSettings(String extensionName, String hostAddress, String hostPort, String opensearchAddress, String opensearchPort) {
         super();
@@ -77,5 +86,22 @@ public class ExtensionSettings {
             + ", opensearchPort="
             + opensearchPort
             + "}";
+    }
+
+    /**
+     * Helper method to read extension settings from a YAML file.
+     *
+     * @param extensionSettingsPath The path (relative to the classpath) of the extension settings file.
+     * @return A settings file encapsulating the extension host and port if the file exists, null otherwise.
+     * @throws IOException if there is an error reading the file.
+     */
+    public static ExtensionSettings readSettingsFromYaml(String extensionSettingsPath) throws IOException {
+        URL resource = Extension.class.getResource(extensionSettingsPath);
+        if (resource == null) {
+            return null;
+        }
+        File file = new File(resource.getPath());
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        return objectMapper.readValue(file, ExtensionSettings.class);
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
@@ -16,33 +16,29 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.File;
+import java.io.IOException;
 
 public class TestExtensionSettings extends OpenSearchTestCase {
-    private static final String EXTENSION_DESCRIPTOR = "src/test/resources/extension.yml";
+    private static final String EXTENSION_DESCRIPTOR_CLASSPATH = "/extension.yml";
+    private static final String EXTENSION_DESCRIPTOR_FILEPATH = "src/test/resources" + EXTENSION_DESCRIPTOR_CLASSPATH;
     private ExtensionSettings extensionSettings;
 
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        File file = new File(EXTENSION_DESCRIPTOR);
+        File file = new File(EXTENSION_DESCRIPTOR_FILEPATH);
         ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
         extensionSettings = objectMapper.readValue(file, ExtensionSettings.class);
     }
 
     @Test
-    public void testExtensionName() {
+    public void testSettingsStrings() {
         assertEquals("sample-extension", extensionSettings.getExtensionName());
-    }
-
-    @Test
-    public void testHostAddress() {
         assertEquals("127.0.0.1", extensionSettings.getHostAddress());
-    }
-
-    @Test
-    public void testHostPort() {
         assertEquals("4532", extensionSettings.getHostPort());
+        assertEquals("127.0.0.1", extensionSettings.getOpensearchAddress());
+        assertEquals("9200", extensionSettings.getOpensearchPort());
     }
 
     @Test
@@ -53,5 +49,18 @@ public class TestExtensionSettings extends OpenSearchTestCase {
         assertEquals("baz", settings.getHostPort());
         assertEquals("os", settings.getOpensearchAddress());
         assertEquals("port", settings.getOpensearchPort());
+    }
+
+    @Test
+    public void testReadSettingsFromYaml() throws IOException {
+        ExtensionSettings settings = ExtensionSettings.readSettingsFromYaml(EXTENSION_DESCRIPTOR_CLASSPATH);
+        assertNotNull(settings);
+        assertEquals(extensionSettings.getExtensionName(), settings.getExtensionName());
+        assertEquals(extensionSettings.getHostAddress(), settings.getHostAddress());
+        assertEquals(extensionSettings.getHostPort(), settings.getHostPort());
+        assertEquals(extensionSettings.getOpensearchAddress(), settings.getOpensearchAddress());
+        assertEquals(extensionSettings.getOpensearchPort(), settings.getOpensearchPort());
+        assertNull(ExtensionSettings.readSettingsFromYaml("this/path/does/not/exist"));
+        assertNull(ExtensionSettings.readSettingsFromYaml(EXTENSION_DESCRIPTOR_CLASSPATH + "filedoesnotexist"));
     }
 }

--- a/src/test/resources/extension.yml
+++ b/src/test/resources/extension.yml
@@ -1,3 +1,5 @@
 extensionName: sample-extension
 hostAddress: 127.0.0.1
 hostPort: 4532
+opensearchAddress: 127.0.0.1
+opensearchPort: 9200


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

 - Moves `readSettingsFromYaml()` to the `ExtensionSettings` object where it makes more sense to be
 - Adds test coverage

### Issues Resolved

Fixes #252 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
