### PR TITLE
Don't evaluate git diff on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,21 +155,14 @@ jacocoTestReport {
 // https://github.com/form-com/diff-coverage-gradle/issues/73
 ext.createDiffFile = { ->
     def file = Files.createTempFile(URLEncoder.encode(project.name, 'UTF-8'), '.diff').toFile()
-    // ref for local runs
     def diffBase = 'refs/remotes/origin/main'
-    if (System.getenv('CI')) {
-        if (System.getenv('GITHUB_BASE_REF')) {
-            // we are on a PR
-            diffBase = 'origin/' + System.getenv('GITHUB_BASE_REF')
-        } else {
-            // we are on main branch, no diff
-            diffBase = 'HEAD'
-        }
-    }
-    file.withOutputStream { out ->
-        exec {
-            commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
-            standardOutput = out
+    // Only run locally
+    if (!System.getenv('CI')) {
+        file.withOutputStream { out ->
+            exec {
+                commandLine 'git', 'diff', '--no-color', '--minimal', diffBase
+                standardOutput = out
+            }
         }
     }
     return file


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

The function to generate the git diff file for `gradle diffCoverage` doesn't play nicely with our CI scripts which copy SDK over to extensions.  

This PR just suppresses the diff generation entirely for GitHub actions, so it will only work locally. This is fine as it's not currently run in CI.  If we decide to run it (see #250) we can figure out how to make it work properly then.

### Issues Resolved

Continuing to tweak #248 to not break CI. Update of #251 that didn't fix it for external projects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
