### PR TITLE
Enforce minimum guava version to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     def nettyVersion = "4.1.85.Final"
     def luceneVersion = "9.4.2"
     def jacksonDatabindVersion = "2.14.0"
+    def guavaVersion = "31.1-jre"
     def junit4Version = "4.13.2"
     def junit5Version = "5.9.1"
     def jaxbVersion = "2.3.1"
@@ -92,6 +93,11 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jacksonDatabindVersion}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonDatabindVersion}")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-guava:${jacksonDatabindVersion}")
+    constraints {
+        implementation("com.google.guava:guava:${guavaVersion}") {
+            because 'versions below 30.0 have active CVE'
+        }
+    }
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junit5Version}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junit5Version}")
     testImplementation("org.opensearch.test:framework:${opensearchVersion}")


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Guava versions before 24.1.1 are subject to CVE-2018-10237.
Guava versions before 30.0 are subject to CVE-2020-8908.

Jackson [by default uses Guava version 21.0](https://github.com/FasterXML/jackson-datatypes-collections/tree/2.15/guava#guava-compatibility). This PR forces a later version of this transitive dependency.

Before this fix:
```
$ ./gradlew -q dependencyInsight --dependency guava:guava 
com.google.guava:guava:21.0
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 11           |

com.google.guava:guava:21.0
\--- com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.0
     +--- compileClasspath
     \--- com.fasterxml.jackson:jackson-bom:2.14.0
          \--- com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.0 (*)
```

After this fix:
```
$ ./gradlew -q dependencyInsight --dependency guava:guava 
com.google.guava:guava:31.1-jre
  Variant compile:
    | Attribute Name                 | Provided | Requested    |
    |--------------------------------|----------|--------------|
    | org.gradle.status              | release  |              |
    | org.gradle.category            | library  | library      |
    | org.gradle.libraryelements     | jar      | classes      |
    | org.gradle.usage               | java-api | java-api     |
    | org.gradle.dependency.bundling |          | external     |
    | org.gradle.jvm.environment     |          | standard-jvm |
    | org.gradle.jvm.version         |          | 11           |
   Selection reasons:
      - By constraint: versions below 30.0 have active CVE
      - By conflict resolution: between versions 31.1-jre and 21.0

com.google.guava:guava:31.1-jre
\--- compileClasspath

com.google.guava:guava:21.0 -> 31.1-jre
\--- com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.0
     +--- compileClasspath
     \--- com.fasterxml.jackson:jackson-bom:2.14.0
          \--- com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.0 (*)
```


### Issues Resolved
Fixes #269 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
