### PR TITLE
Integrate Mend Renovate config into Mend for Github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    ":gitSignOff"
-  ]
-}

--- a/.whitesource
+++ b/.whitesource
@@ -15,6 +15,12 @@
     "issueType": "DEPENDENCY"
   },
   "remediateSettings": {
+    "enableRenovate": true,
+    "extends": [
+      "config:base",
+      ":gitSignOff",
+      "github>whitesource/merge-confidence:beta"
+    ]
     "workflowRules": {
       "enabled": true
     }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

We recently installed the stand-alone open source [Renovate app](https://docs.renovatebot.com/) to maintain our dependencies as a replacement/improvement over Dependabot. While open source, this app is developed by Mend (formerly Whitesource).

More recently, the [Mend for Github](https://github.com/apps/mend-for-github-com) app was installed organization-wide, including this repo (see #267).   Mend has an internal implementation of Renovate using the same Open Source engine.

Running the two side by side works but is confusing with two separate dependency tracking issues, one for Renovate (#266) and one for Mend for Github (#268).

_Describe what this change achieves._

This PR moves our configuration for the Mend Renovate app (in `.github/renovate.json`) into the Mend for Github configuration file (`.whitesource`).

What I expect to happen:
1. The Mend for Github Dependency Tracker issue (#268) will be updated with the dependency tracking information presently in #266.
2. The Mend Renovate Dependency Tracker issue might auto-close when we remove the `renovate.json` file. 
  - Or it might stay and we may have to close it ourselves.
3. There will probably be a duplicate dependency PR generated for our one outstanding version update (#263) which itself duplicated the dependabot issue (#261). 
  - or maybe not, who knows?
  - if so I'm not sure what would happen if we closed #263 without closing the new PR, but we can always regenerate it if it breaks things

What will actually happen:

TBD, but we can always revert. :)

In any case, I think merging configs is the right way to go, and there may be a follow-up PR or issue closures to try to clean up anything missed.

### Issues Resolved

Fixes #273 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
