### PR TITLE
Don't duplicate workflow runs for Mend PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Gradle Build
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
+      - 'whitesource-remediate/**'
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -2,7 +2,7 @@ name: Validate Gradle Wrapper
 on:
   push:
     branches-ignore:
-      - 'dependabot/**'
+      - 'whitesource-remediate/**'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Because Mend generates PRs in branches on this repo, they trigger workflows for pushes in addition to pull requests.

This was previously fixed with the dependabot config in #232.  This is the equivalent of that PR for Remediate (Renovate).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
