### PR TITLE
Added query for initialized extensions

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -407,6 +407,7 @@ public class ExtensionsRunner {
         try {
             transportService.sendRequest(
                 opensearchNode,
+                uniqueId,
                 ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
                 new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),
                 extensionDependencyResponseHandler

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -396,7 +396,7 @@ public class ExtensionsRunner {
     }
 
     /**
-     * Request the Dependency Information from Opensearch. The result will be handled by a {@Link ExtensionDependencyResponseHandler}.
+     * Request the Dependency Information from Opensearch. The result will be handled by a {@link ExtensionDependencyResponseHandler}.
      *
      * @param transportService  The TransportService defining the connection to OpenSearch
      * @return A List contains details of this extension's dependencies

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -407,8 +407,8 @@ public class ExtensionsRunner {
         try {
             transportService.sendRequest(
                 opensearchNode,
-                uniqueId,
-                new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),
+                ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
+                new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION, uniqueId),
                 extensionDependencyResponseHandler
             );
             // Wait on Extension Dependency response

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -406,7 +406,6 @@ public class ExtensionsRunner {
         ExtensionDependencyResponseHandler extensionDependencyResponseHandler = new ExtensionDependencyResponseHandler();
         try {
             transportService.sendRequest(
-                uniqueId,
                 opensearchNode,
                 ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
                 new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -32,6 +32,8 @@ import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.AcknowledgedResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionBooleanResponseHandler;
+import org.opensearch.sdk.handlers.ExtensionDependencyResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionsIndicesModuleNameRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsIndicesModuleRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
@@ -392,6 +394,34 @@ public class ExtensionsRunner {
         // At this point, response handler has read in the cluster state
         return clusterStateResponseHandler.getClusterState();
     }
+
+    /**
+     * Request the Dependency Information from Opensearch. 
+     * @param transportService
+     * @return The dependency information of Extension
+     */
+
+     public List<DiscoveryExtensionNode> sendExtensionDependencyRequest(TransportService transportService) {
+        logger.info("Sending Extension Dependency Information request to Opensearch");
+        ExtensionDependencyResponseHandler extensionDependencyResponseHandler = new ExtensionDependencyResponseHandler();
+        try{
+            transportService.sendRequest(
+                opensearchNode,
+                ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
+                new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),
+                extensionDependencyResponseHandler
+            );
+            //Wait on Extension Dependency response
+            extensionDependencyResponseHandler.awaitResponse();
+        }catch (InterruptedException e) {
+            logger.info("Failed to recieve Extension Dependency response from OpenSearch", e);
+        }catch (Exception e) {
+            logger.info("Failed to send Extension Dependency request to OpenSearch", e);
+        }
+
+        // At this point, response handler has read in the extension dependency
+        return extensionDependencyResponseHandler.getExtensionDependency();
+     }
 
     /**
      * Requests the cluster settings from OpenSearch.  The result will be handled by a {@link ClusterSettingsResponseHandler}.

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -415,7 +415,7 @@ public class ExtensionsRunner {
             );
             // Wait on Extension Dependency response
             extensionDependencyResponseHandler.awaitResponse();
-        } catch (CancellationException e) {
+        } catch (TimeoutException e) {
             logger.warn("Failed to send Extension Dependency request to OpenSearch", e);
         }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -396,32 +396,32 @@ public class ExtensionsRunner {
     }
 
     /**
-     * Request the Dependency Information from Opensearch. 
+     * Request the Dependency Information from Opensearch.
      * @param transportService
      * @return The dependency information of Extension
      */
 
-     public List<DiscoveryExtensionNode> sendExtensionDependencyRequest(TransportService transportService) {
+    public List<DiscoveryExtensionNode> sendExtensionDependencyRequest(TransportService transportService) {
         logger.info("Sending Extension Dependency Information request to Opensearch");
         ExtensionDependencyResponseHandler extensionDependencyResponseHandler = new ExtensionDependencyResponseHandler();
-        try{
+        try {
             transportService.sendRequest(
                 opensearchNode,
                 ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
                 new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),
                 extensionDependencyResponseHandler
             );
-            //Wait on Extension Dependency response
+            // Wait on Extension Dependency response
             extensionDependencyResponseHandler.awaitResponse();
-        }catch (InterruptedException e) {
-            logger.info("Failed to recieve Extension Dependency response from OpenSearch", e);
-        }catch (Exception e) {
+        } catch (InterruptedException e) {
+            logger.info("Failed to receive Extension Dependency response from OpenSearch", e);
+        } catch (Exception e) {
             logger.info("Failed to send Extension Dependency request to OpenSearch", e);
         }
 
         // At this point, response handler has read in the extension dependency
         return extensionDependencyResponseHandler.getExtensionDependency();
-     }
+    }
 
     /**
      * Requests the cluster settings from OpenSearch.  The result will be handled by a {@link ClusterSettingsResponseHandler}.

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -32,7 +32,6 @@ import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.AcknowledgedResponseHandler;
-import org.opensearch.sdk.handlers.ExtensionBooleanResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionDependencyResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionsIndicesModuleNameRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsIndicesModuleRequestHandler;
@@ -398,7 +397,7 @@ public class ExtensionsRunner {
 
     /**
      * Request the Dependency Information from Opensearch. The result will be handled by a {@Link ExtensionDependencyResponseHandler}.
-     * 
+     *
      * @param transportService  The TransportService defining the connection to OpenSearch
      * @return A List contains details of this extension's dependencies
      */

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -416,7 +415,9 @@ public class ExtensionsRunner {
             // Wait on Extension Dependency response
             extensionDependencyResponseHandler.awaitResponse();
         } catch (TimeoutException e) {
-            logger.warn("Failed to send Extension Dependency request to OpenSearch", e);
+            logger.info("Failed to receive Extension Dependency response from OpenSearch", e);
+        } catch (Exception e) {
+            logger.info("Failed to send Extension Dependency request to OpenSearch", e);
         }
 
         // At this point, response handler has read in the extension dependency

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -414,7 +415,7 @@ public class ExtensionsRunner {
             );
             // Wait on Extension Dependency response
             extensionDependencyResponseHandler.awaitResponse();
-        } catch (TimeoutException e) {
+        } catch (CancellationException e) {
             logger.warn("Failed to send Extension Dependency request to OpenSearch", e);
         }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -408,7 +408,6 @@ public class ExtensionsRunner {
             transportService.sendRequest(
                 opensearchNode,
                 uniqueId,
-                ExtensionsManager.REQUEST_EXTENSION_DEPENDENCY_INFORMATION,
                 new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_DEPENDENCY_INFORMATION),
                 extensionDependencyResponseHandler
             );

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -73,10 +73,7 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
      *     if the response failed
      */
     public void awaitResponse() throws Exception {
-        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
-        if (inProgressFuture.isCompletedExceptionally()) {
-            inProgressFuture.get();
-        }
+        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS).get();
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -42,13 +42,13 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
         // Set cluster state from response
         this.extensions = response.getExtensionDependencies();
-        inProgressLatch.countDown();
+        inProgressFuture.complete(response);
     }
 
     @Override
     public void handleException(TransportException exp) {
         logger.info("ExtensionDependencyRequest failed", exp);
-        inProgressFuture.complete(response);
+        inProgressFuture.completeExceptionally(exp);
     }
 
     @Override

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -12,7 +12,6 @@ package org.opensearch.sdk.handlers;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
@@ -39,7 +38,6 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
     @Override
     public void handleResponse(ExtensionDependencyResponse response) {
-        logger.info("received {}", response);
 
         // Set cluster state from response
         this.extensions = response.getExtensionDependencies();
@@ -48,7 +46,7 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
     @Override
     public void handleException(TransportException exp) {
-        logger.info("ExtensionDependencyRequest failed", exp);
+        logger.info("ExtensionDependencyResponseHandler failed", exp);
         inProgressFuture.completeExceptionally(exp);
     }
 
@@ -65,7 +63,9 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
     /**
      * Invokes await on the ExtensionDependencyResponseHandler count down latch
      * @throws Exception
-     *     if the response times out
+     *     if the response times out,
+     *     if the response has been cancelled
+     *     if the response failed
      */
     public void awaitResponse() throws Exception {
         inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -25,7 +25,7 @@ import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 
 /**
- * This class handles the response from OpenSearch to a {@link ExtensionsRunner#sendExtensionDependencyRequest(TransportService)} call.
+ * This class handles the response from OpenSearch to a {@link ExtensionsRunner#sendExtensionDependencyRequest} call.
  */
 public class ExtensionDependencyResponseHandler implements TransportResponseHandler<ExtensionDependencyResponse> {
     private static final Logger logger = LogManager.getLogger(ExtensionDependencyResponseHandler.class);

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -12,6 +12,7 @@ package org.opensearch.sdk.handlers;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
@@ -63,10 +64,10 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
     /**
      * Invokes await on the ExtensionDependencyResponseHandler count down latch
-     * @throws Exception
+     * @throws ExecutionException
      *     if the response times out
      */
-    public void awaitResponse() throws InterruptedException {
+    public void awaitResponse() throws ExecutionException {
         inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
         if (inProgressFuture.isCompletedExceptionally()) {
             inProgressFuture.get();

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -29,7 +29,7 @@ import org.opensearch.transport.TransportResponseHandler;
  */
 public class ExtensionDependencyResponseHandler implements TransportResponseHandler<ExtensionDependencyResponse> {
     private static final Logger logger = LogManager.getLogger(ExtensionDependencyResponseHandler.class);
-    private final CompleteableFuture<ExtensionDependencyResponse> inProgressFuture;
+    private final CompletableFuture<ExtensionDependencyResponse> inProgressFuture;
     private List<DiscoveryExtensionNode> extensions;
 
     public ExtensionDependencyResponseHandler() {
@@ -64,10 +64,10 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
     /**
      * Invokes await on the ExtensionDependencyResponseHandler count down latch
-     * @throws ExecutionException
+     * @throws Exception
      *     if the response times out
      */
-    public void awaitResponse() throws ExecutionException {
+    public void awaitResponse() throws Exception {
         inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
         if (inProgressFuture.isCompletedExceptionally()) {
             inProgressFuture.get();

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -20,6 +20,7 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.extensions.DiscoveryExtensionNode;
 import org.opensearch.extensions.ExtensionDependencyResponse;
 import org.opensearch.extensions.ExtensionsManager;
+import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -80,7 +80,8 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
     }
 
     /**
-     * Get the dependency information
+     * Get the dependency information form the Response
+     * @return dependency information
      */
     public List<DiscoveryExtensionNode> getExtensionDependencies() {
         return this.extensions;

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.handlers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.extensions.DiscoveryExtensionNode;
+import org.opensearch.extensions.ExtensionsManager;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
+
+/**
+ * This class handles the response from OpenSearch to a {@link ExtensionsRunner#sendExtensionDependencyRequest(TransportService)} call.
+ */
+public class ExtensionDependencyResponseHandler implements TransportResponseHandler<ExtensionDependencyResponse> {
+    private static final Logger logger = LogManager.getLogger(ExtensionDependencyResponseHandler.class);
+    private final CountDownLatch inProgressLatch;
+    private List<DiscoveryExtensionNode> extensions;
+
+    public ExtensionDependencyResponseHandler(){
+        this.inProgressLatch = new CountDownLatch(1);
+        this.extensions = extensions.emptyList;
+    }
+
+    @Override
+    public void handleResponse(ExtensionDependencyResponse response) {
+        logger.info("received {}", response);
+
+        // Set cluster state from response
+        this.extensions = response.getExtensionDependency();
+        inProgressLatch.countDown();
+    }
+
+    @Override
+    public void handleException(TransportException exp) {
+        logger.info("ExtensionDependencyRequest failed", exp);
+        inProgressLatch.countDown();
+    }
+
+    @Override
+    public String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    public ExtensionDependencyResponse read(StreamInput in) throws IOException {
+        return new ExtensionDependencyResponse(in);
+    }
+
+    /**
+     * Invokes await on the ExtensionDependencyResponseHandler count down latch
+     * @throws InterruptedException
+     *     if the response times out
+     */
+    public void awaitResponse() throws InterruptedException {
+        inProgressLatch.await(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+    }
+
+    public List<DiscoveryExtensionNode> getExtensionDependency() {
+        return this.extensions;
+    }
+}

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -41,7 +41,7 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
     public void handleResponse(ExtensionDependencyResponse response) {
 
         // Set cluster state from response
-        this.extensions = response.getExtensionDependencies();
+        this.extensions = response.getExtensionDependency();
         inProgressFuture.complete(response);
     }
 

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -31,7 +31,7 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
     private final CountDownLatch inProgressLatch;
     private List<DiscoveryExtensionNode> extensions;
 
-    public ExtensionDependencyResponseHandler(){
+    public ExtensionDependencyResponseHandler() {
         this.inProgressLatch = new CountDownLatch(1);
         this.extensions = extensions.emptyList;
     }

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -33,6 +33,9 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
     private final CompletableFuture<ExtensionDependencyResponse> inProgressFuture;
     private List<DiscoveryExtensionNode> extensions;
 
+    /**
+     * Instantiates a new ExtensionDependencyHandler with ConpletableFuture
+     */
     public ExtensionDependencyResponseHandler() {
         this.inProgressFuture = new CompletableFuture<>();
         this.extensions = extensions;
@@ -76,6 +79,9 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
         }
     }
 
+    /**
+     * Get the dependency information
+     */
     public List<DiscoveryExtensionNode> getExtensionDependencies() {
         return this.extensions;
     }

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionDependencyResponseHandler.java
@@ -18,6 +18,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.extensions.DiscoveryExtensionNode;
+import org.opensearch.extensions.ExtensionDependencyResponse;
 import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
@@ -33,7 +34,7 @@ public class ExtensionDependencyResponseHandler implements TransportResponseHand
 
     public ExtensionDependencyResponseHandler() {
         this.inProgressFuture = new CompletableFuture<>();
-        this.extensions = extensions.emptyList;
+        this.extensions = extensions;
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Frank Lou <mloufra@amazon.com>

### Description
Create a feature to have an extension query to OpenSearch to obtain a list of initialized extensions and determine whether a particular extension is initialized.
Equivalent PR on OpenSearch : ~https://github.com/opensearch-project/OpenSearch/pull/5628~ https://github.com/opensearch-project/OpenSearch/pull/5658
### Issues Resolved
fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
