### PR TITLE
Replace CountDownLatches for response handlers with CompletableFutures

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 /**
@@ -383,8 +384,8 @@ public class ExtensionsRunner {
             );
             // Wait on cluster state response
             clusterStateResponseHandler.awaitResponse();
-        } catch (InterruptedException e) {
-            logger.info("Failed to recieve Cluster State response from OpenSearch", e);
+        } catch (TimeoutException e) {
+            logger.info("Failed to receive Cluster State response from OpenSearch", e);
         } catch (Exception e) {
             logger.info("Failed to send Cluster State request to OpenSearch", e);
         }
@@ -425,8 +426,8 @@ public class ExtensionsRunner {
             );
             // Wait on environment settings response
             environmentSettingsResponseHandler.awaitResponse();
-        } catch (InterruptedException e) {
-            logger.info("Failed to recieve Environment Settings response from OpenSearch", e);
+        } catch (TimeoutException e) {
+            logger.info("Failed to receive Environment Settings response from OpenSearch", e);
         } catch (Exception e) {
             logger.info("Failed to send Environment Settings request to OpenSearch", e);
         }

--- a/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
@@ -22,7 +22,7 @@ import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -30,14 +30,14 @@ import java.util.concurrent.TimeUnit;
  */
 public class ClusterStateResponseHandler implements TransportResponseHandler<ClusterStateResponse> {
     private static final Logger logger = LogManager.getLogger(ClusterStateResponseHandler.class);
-    private final CountDownLatch inProgressLatch;
+    private final CompletableFuture<ClusterStateResponse> inProgressFuture;
     private ClusterState clusterState;
 
     /**
     * Instantiates a new ClusterStateResponseHandler with a count down latch and an empty ClusterState object
     */
     public ClusterStateResponseHandler() {
-        this.inProgressLatch = new CountDownLatch(1);
+        this.inProgressFuture = new CompletableFuture<>();
         this.clusterState = ClusterState.EMPTY_STATE;
     }
 
@@ -47,13 +47,13 @@ public class ClusterStateResponseHandler implements TransportResponseHandler<Clu
 
         // Set cluster state from response
         this.clusterState = response.getState();
-        inProgressLatch.countDown();
+        inProgressFuture.complete(response);
     }
 
     @Override
     public void handleException(TransportException exp) {
         logger.info("ExtensionClusterStateRequest failed", exp);
-        inProgressLatch.countDown();
+        inProgressFuture.completeExceptionally(exp);
     }
 
     @Override
@@ -68,11 +68,14 @@ public class ClusterStateResponseHandler implements TransportResponseHandler<Clu
 
     /**
      * Invokes await on the ClusterStateResponseHandler count down latch
-     * @throws InterruptedException
+     * @throws Exception
      *     if the response times out
      */
-    public void awaitResponse() throws InterruptedException {
-        inProgressLatch.await(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+    public void awaitResponse() throws Exception {
+        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        if (inProgressFuture.isCompletedExceptionally()) {
+            inProgressFuture.get();
+        }
     }
 
     public ClusterState getClusterState() {

--- a/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
@@ -72,10 +72,7 @@ public class ClusterStateResponseHandler implements TransportResponseHandler<Clu
      *     if the response times out
      */
     public void awaitResponse() throws Exception {
-        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
-        if (inProgressFuture.isCompletedExceptionally()) {
-            inProgressFuture.get();
-        }
+        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS).get();
     }
 
     public ClusterState getClusterState() {

--- a/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
@@ -72,10 +72,7 @@ public class EnvironmentSettingsResponseHandler implements TransportResponseHand
      *        if the response times out
      */
     public void awaitResponse() throws Exception {
-        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
-        if (inProgressFuture.isCompletedExceptionally()) {
-            inProgressFuture.get();
-        }
+        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS).get();
     }
 
     public Settings getEnvironmentSettings() {

--- a/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/EnvironmentSettingsResponseHandler.java
@@ -21,7 +21,7 @@ import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -30,14 +30,14 @@ import java.util.concurrent.TimeUnit;
 public class EnvironmentSettingsResponseHandler implements TransportResponseHandler<EnvironmentSettingsResponse> {
 
     private static final Logger logger = LogManager.getLogger(EnvironmentSettingsResponseHandler.class);
-    private final CountDownLatch inProgressLatch;
+    private final CompletableFuture<EnvironmentSettingsResponse> inProgressFuture;
     private Settings environmentSettings;
 
     /**
     * Instantiates a new EnvironmentSettingsResponseHandler with a count down latch and an empty Settings object
     */
     public EnvironmentSettingsResponseHandler() {
-        this.inProgressLatch = new CountDownLatch(1);
+        this.inProgressFuture = new CompletableFuture<>();
         this.environmentSettings = Settings.EMPTY;
     }
 
@@ -47,13 +47,13 @@ public class EnvironmentSettingsResponseHandler implements TransportResponseHand
 
         // Set environmentSettings from response
         this.environmentSettings = response.getEnvironmentSettings();
-        inProgressLatch.countDown();
+        inProgressFuture.complete(response);
     }
 
     @Override
     public void handleException(TransportException exp) {
         logger.info("EnvironmentSettingsRequest failed", exp);
-        inProgressLatch.countDown();
+        inProgressFuture.completeExceptionally(exp);
     }
 
     @Override
@@ -68,11 +68,14 @@ public class EnvironmentSettingsResponseHandler implements TransportResponseHand
 
     /**
      * Invokes await on the EnvironmentSettingsResponseHandler count down latch
-     * @throws InterruptedException
+     * @throws Exception
      *        if the response times out
      */
-    public void awaitResponse() throws InterruptedException {
-        inProgressLatch.await(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+    public void awaitResponse() throws Exception {
+        inProgressFuture.orTimeout(ExtensionsManager.EXTENSION_REQUEST_WAIT_TIMEOUT, TimeUnit.SECONDS);
+        if (inProgressFuture.isCompletedExceptionally()) {
+            inProgressFuture.get();
+        }
     }
 
     public Settings getEnvironmentSettings() {


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Replaces synchronous CountDownLatches with asynchronous CompletableFutures

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/292

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
