### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,14 +1,14 @@
-# OpenSearch-SDK-Java Maintainers
+## Overview
 
-## Maintainers
-| Maintainer              | GitHub ID                                               | Affiliation |
-| ----------------------- | ------------------------------------------------------- | ----------- |
-| Charlotte Henkle        | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
-| Josh Palis              | [joshpalis](https://github.com/joshpalis)               | Amazon      |
-| Owais Kazi              | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
-| Ryan Bogan              | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |
-| Sarat Vemulapalli       | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
-| Dan Widdis              | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
+## Current Maintainers
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
+| Josh Palis        | [joshpalis](https://github.com/joshpalis)               | Amazon      |
+| Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
+| Ryan Bogan        | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |
+| Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
+| Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.