### PR TITLE
Create formatted error response messages for exceptions

### DIFF
--- a/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtensionRestHandler.java
@@ -86,9 +86,10 @@ public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
      * @return an ExtensionRestResponse identifying the unhandled request.
      */
     protected ExtensionRestResponse unhandledRequest(ExtensionRestRequest request) {
-        return createJsonErrorResponse(
+        return createJsonResponse(
             request,
             NOT_FOUND,
+            "error",
             "Extension REST action improperly configured to handle: [" + request.toString() + "]"
         );
     }
@@ -100,7 +101,7 @@ public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
      * @return an ExtensionRestResponse identifying the exception
      */
     protected ExtensionRestResponse exceptionalRequest(ExtensionRestRequest request, Exception e) {
-        return createJsonErrorResponse(request, INTERNAL_SERVER_ERROR, "Request failed with exception: [" + e.getMessage() + "]");
+        return createJsonResponse(request, INTERNAL_SERVER_ERROR, "error", "Request failed with exception: [" + e.getMessage() + "]");
     }
 
     /**
@@ -108,20 +109,26 @@ public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
      *
      * @param request The request to respond to
      * @param status The response status to send
+     * @param fieldName The field name for the response string
      * @param responseStr The string to include
-     * @return an ExtensionRestResponse in JSON format including the specified string as the content of a field named "error"
+     * @return an ExtensionRestResponse in JSON format including the specified string as the content of the specified field
      */
-    protected ExtensionRestResponse createJsonErrorResponse(ExtensionRestRequest request, RestStatus status, String responseStr) {
+    protected ExtensionRestResponse createJsonResponse(
+        ExtensionRestRequest request,
+        RestStatus status,
+        String fieldName,
+        String responseStr
+    ) {
         try {
             return new ExtensionRestResponse(
                 request,
                 status,
-                JsonXContent.contentBuilder().startObject().field("error", responseStr).endObject()
+                JsonXContent.contentBuilder().startObject().field(fieldName, responseStr).endObject()
             );
         } catch (IOException e) {
             // This Should Never Happen (TM)
             // If we messed up JSON code above, just send plain text
-            return new ExtensionRestResponse(request, status, responseStr);
+            return new ExtensionRestResponse(request, status, fieldName + ": " + responseStr);
         }
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestBaseExtensionRestHandler.java
+++ b/src/test/java/org/opensearch/sdk/TestBaseExtensionRestHandler.java
@@ -33,7 +33,7 @@ public class TestBaseExtensionRestHandler extends OpenSearchTestCase {
         private Function<ExtensionRestRequest, ExtensionRestResponse> handleFoo = (request) -> {
             try {
                 if ("bar".equals(request.content().utf8ToString())) {
-                    return createJsonErrorResponse(request, RestStatus.OK, "bar");
+                    return createJsonResponse(request, RestStatus.OK, "success", "bar");
                 }
                 throw new IllegalArgumentException("no bar");
             } catch (Exception e) {
@@ -62,7 +62,7 @@ public class TestBaseExtensionRestHandler extends OpenSearchTestCase {
         );
         ExtensionRestResponse response = handler.handleRequest(successfulRequest);
         assertEquals(RestStatus.OK, response.status());
-        assertEquals("{\"error\":\"bar\"}", response.content().utf8ToString());
+        assertEquals("{\"success\":\"bar\"}", response.content().utf8ToString());
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestBaseExtensionRestHandler.java
+++ b/src/test/java/org/opensearch/sdk/TestBaseExtensionRestHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.bytes.BytesArray;
+import org.opensearch.extensions.rest.ExtensionRestRequest;
+import org.opensearch.extensions.rest.ExtensionRestResponse;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TestBaseExtensionRestHandler extends OpenSearchTestCase {
+
+    private final BaseExtensionRestHandler handler = new BaseExtensionRestHandler() {
+        @Override
+        public List<RouteHandler> routeHandlers() {
+            return List.of(new RouteHandler(Method.GET, "foo", handleFoo));
+        }
+
+        private Function<ExtensionRestRequest, ExtensionRestResponse> handleFoo = (request) -> {
+            try {
+                if ("bar".equals(request.content().utf8ToString())) {
+                    return createJsonErrorResponse(request, RestStatus.OK, "bar");
+                }
+                throw new IllegalArgumentException("no bar");
+            } catch (Exception e) {
+                return exceptionalRequest(request, e);
+            }
+        };
+    };
+
+    @Test
+    public void testHandlerDefaultRoutes() {
+        BaseExtensionRestHandler defaultHandler = new BaseExtensionRestHandler() {
+        };
+        assertTrue(defaultHandler.routes().isEmpty());
+        assertTrue(defaultHandler.routeHandlers().isEmpty());
+    }
+
+    @Test
+    public void testJsonErrorResponse() {
+        ExtensionRestRequest successfulRequest = new ExtensionRestRequest(
+            Method.GET,
+            "foo",
+            Collections.emptyMap(),
+            null,
+            new BytesArray("bar".getBytes(StandardCharsets.UTF_8)),
+            ""
+        );
+        ExtensionRestResponse response = handler.handleRequest(successfulRequest);
+        assertEquals(RestStatus.OK, response.status());
+        assertEquals("{\"error\":\"bar\"}", response.content().utf8ToString());
+    }
+
+    @Test
+    public void testErrorResponseOnException() {
+        ExtensionRestRequest exceptionalRequest = new ExtensionRestRequest(
+            Method.GET,
+            "foo",
+            Collections.emptyMap(),
+            null,
+            new BytesArray("baz".getBytes(StandardCharsets.UTF_8)),
+            ""
+        );
+        ExtensionRestResponse response = handler.handleRequest(exceptionalRequest);
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, response.status());
+        assertEquals("{\"error\":\"Request failed with exception: [no bar]\"}", response.content().utf8ToString());
+    }
+
+    @Test
+    public void testErrorResponseOnUnhandled() {
+        ExtensionRestRequest unhandledRequestMethod = new ExtensionRestRequest(
+            Method.PUT,
+            "foo",
+            Collections.emptyMap(),
+            null,
+            new BytesArray(new byte[0]),
+            ""
+        );
+        ExtensionRestResponse response = handler.handleRequest(unhandledRequestMethod);
+        assertEquals(RestStatus.NOT_FOUND, response.status());
+        assertEquals(
+            "{\"error\":\"Extension REST action improperly configured to handle: [" + unhandledRequestMethod + "]\"}",
+            response.content().utf8ToString()
+        );
+
+        ExtensionRestRequest unhandledRequestPath = new ExtensionRestRequest(
+            Method.GET,
+            "foobar",
+            Collections.emptyMap(),
+            null,
+            new BytesArray(new byte[0]),
+            ""
+        );
+        response = handler.handleRequest(unhandledRequestPath);
+        assertEquals(RestStatus.NOT_FOUND, response.status());
+        assertEquals(
+            "{\"error\":\"Extension REST action improperly configured to handle: [" + unhandledRequestPath + "]\"}",
+            response.content().utf8ToString()
+        );
+
+    }
+}

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/rest/TestRestHelloAction.java
@@ -10,7 +10,6 @@
 package org.opensearch.sdk.sample.helloworld.rest;
 
 import java.nio.charset.StandardCharsets;
-import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,8 @@ public class TestRestHelloAction extends OpenSearchTestCase {
     private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
     private ExtensionRestHandler restHelloAction;
-    private static final String EXTENSION_NAME = "hello-world";
+    // Temporarily removed pending integration of feature/identity branch
+    // private static final String EXTENSION_NAME = "hello-world";
 
     @Override
     @BeforeEach
@@ -59,8 +59,9 @@ public class TestRestHelloAction extends OpenSearchTestCase {
 
     @Test
     public void testHandleRequest() {
-        Principal userPrincipal = () -> "user1";
-        String extensionTokenProcessor = "placeholder_extension_token_processor";
+        // Temporarily removed pending integration of feature/identity branch
+        // Principal userPrincipal = () -> "user1";
+        // String extensionTokenProcessor = "placeholder_extension_token_processor";
         String token = "placeholder_token";
         Map<String, String> params = Collections.emptyMap();
 
@@ -202,21 +203,21 @@ public class TestRestHelloAction extends OpenSearchTestCase {
         // Not registered, fails on method
         response = restHelloAction.handleRequest(unhandledMethodRequest);
         assertEquals(RestStatus.NOT_FOUND, response.status());
-        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(JSON_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("/hi"));
 
         // Not registered, fails on path name
         response = restHelloAction.handleRequest(unhandledPathRequest);
         assertEquals(RestStatus.NOT_FOUND, response.status());
-        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(JSON_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("/hi"));
 
         // Not registered, fails on path length
         response = restHelloAction.handleRequest(unhandledPathLengthRequest);
         assertEquals(RestStatus.NOT_FOUND, response.status());
-        assertEquals(TEXT_CONTENT_TYPE, response.contentType());
+        assertEquals(JSON_CONTENT_TYPE, response.contentType());
         responseStr = new String(BytesReference.toBytes(response.content()), StandardCharsets.UTF_8);
         assertTrue(responseStr.contains("/goodbye"));
     }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Part of AD create/update/validate detector work to conform to the error message format for validation failures. 

Returns JSON-formatted error messages rather than plain text.

### Issues Resolved

Part of #224 and #225 and related issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
