### PR TITLE
Adding maven Snapshots repo for SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,4 +191,19 @@ diffCoverageReport {
         minLines = 0.75
         failOnViolation = true
     }
+
+    publishing {
+        publications {
+        }
+        repositories {
+            maven {
+                name = "Snapshots" //  optional target repository name
+                url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                credentials {
+                    username "$System.env.SONATYPE_USERNAME"
+                    password "$System.env.SONATYPE_PASSWORD"
+                }
+            }
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ version '1.0.0-SNAPSHOT'
 
 publishing {
     publications {
-        group = "org.opensearch.sdk"
-        version = "1.0.0-SNAPSHOT"
+        group = "${group}"
+        version = "${version}"
         mavenJava(MavenPublication) {
             from components.java
         }

--- a/build.gradle
+++ b/build.gradle
@@ -42,13 +42,24 @@ version '1.0.0-SNAPSHOT'
 
 publishing {
     publications {
-        group = "org.opensearch"
+        group = "org.opensearch.sdk"
         version = "1.0.0-SNAPSHOT"
         mavenJava(MavenPublication) {
             from components.java
         }
         sourceCompatibility = 11
         targetCompatibility = 11
+    }
+
+    repositories {
+        maven {
+            name = "Snapshots" //  optional target repository name
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
     }
 }
 
@@ -190,20 +201,5 @@ diffCoverageReport {
         minBranches = 0.60
         minLines = 0.75
         failOnViolation = true
-    }
-
-    publishing {
-        publications {
-        }
-        repositories {
-            maven {
-                name = "Snapshots" //  optional target repository name
-                url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-                credentials {
-                    username "$System.env.SONATYPE_USERNAME"
-                    password "$System.env.SONATYPE_PASSWORD"
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Adding snapshots maven publish to publishing tasks.

```
Publishing tasks
----------------
generateMetadataFileForMavenJavaPublication - Generates the Gradle metadata file for publication 'mavenJava'.
generatePomFileForMavenJavaPublication - Generates the Maven POM file for publication 'mavenJava'.
publish - Publishes all publications produced by this project.
publishAllPublicationsToSnapshotsRepository - Publishes all Maven publications produced by this project to the Snapshots repository.
publishMavenJavaPublicationToMavenLocal - Publishes Maven publication 'mavenJava' to the local Maven repository.
publishMavenJavaPublicationToSnapshotsRepository - Publishes Maven publication 'mavenJava' to Maven repository 'Snapshots'.
publishToMavenLocal - Publishes all Maven publications produced by this project to the local Maven cache.
```

### Issues Resolved
Part of #92 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
