### PR TITLE
Changing return type of getActions to be generic

### DIFF
--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -86,7 +86,7 @@ public interface Extension {
      *
      * @return a list of custom transport actions this extension uses.
      */
-    default Map<String, Class<? extends TransportAction<ActionRequest, ActionResponse>>> getActions() {
+    default Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> getActions() {
         return Collections.emptyMap();
     }
 }

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -33,8 +33,6 @@ public class TransportActions {
     /**
      * Constructor for TransportActions. Creates a map of transportActions for this extension.
      *
-     * @param <Request> the TransportAction request
-     * @param <Response> the TransportAction response
      * @param transportActions is the list of actions the extension would like to register with OpenSearch.
      */
     public TransportActions(

--- a/src/main/java/org/opensearch/sdk/TransportActions.java
+++ b/src/main/java/org/opensearch/sdk/TransportActions.java
@@ -37,8 +37,8 @@ public class TransportActions {
      * @param <Response> the TransportAction response
      * @param transportActions is the list of actions the extension would like to register with OpenSearch.
      */
-    public <Request extends ActionRequest, Response extends ActionResponse> TransportActions(
-        Map<String, Class<? extends TransportAction<Request, Response>>> transportActions
+    public TransportActions(
+        Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> transportActions
     ) {
         this.transportActions = new HashMap<>(transportActions);
     }


### PR DESCRIPTION
Signed-off-by: Varun Jain <varunudr@amazon.com>

### Description
Changing return type of getActions in Extension.java to be more generic

### Issues Resolved
[https://github.com/opensearch-project/opensearch-sdk-java/issues/335](https://github.com/opensearch-project/opensearch-sdk-java/issues/335)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
