### PR TITLE
Only publish snapshots from org repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
       - name: Run Gradle Check
         run: |
           ./gradlew check

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -7,17 +7,19 @@ on:
 
 jobs:
   build-and-publish-snapshots:
+    if: github.repository == 'opensearch-project/opensearch-sdk-java'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: adopt
+          distribution: temurin
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Stops scheduled snapshot workflow from running on forks.

Replaces unsupported AdoptOpenJDK with its successor, Temurin.

### Issues Resolved

Fixes #341

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
