### PR TITLE
Simulate ClusterService methods with SDKClusterService class

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -9,7 +9,11 @@
 
 package org.opensearch.sdk;
 
+import java.util.Map;
+import java.util.function.Consumer;
+
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.settings.Setting;
 
 /**
  * This class simulates methods normally called from OpenSearch ClusterService class.
@@ -34,5 +38,26 @@ public class SDKClusterService {
      */
     public ClusterState state() {
         return extensionsRunner.sendClusterStateRequest(extensionsRunner.getExtensionTransportService());
+    }
+
+    /**
+     * Add a single settings update consumer to OpenSearch
+     *
+     * @param setting The setting for which to consume updates.
+     * @param consumer The consumer of the updates
+     * @throws Exception if the registration of the consumer failed.
+     */
+    public void addSettingsUpdateConsumer(Setting<?> setting, Consumer<?> consumer) throws Exception {
+        addSettingsUpdateConsumer(Map.of(setting, consumer));
+    }
+
+    /**
+     * Add multiple settings update consumers to OpenSearch
+     *
+     * @param settingUpdateConsumers A map of Setting to Consumer.
+     * @throws Exception if the registration of the consumers failed.
+     */
+    public void addSettingsUpdateConsumer(Map<Setting<?>, Consumer<?>> settingUpdateConsumers) throws Exception {
+        extensionsRunner.sendAddSettingsUpdateConsumerRequest(extensionsRunner.getExtensionTransportService(), settingUpdateConsumers);
     }
 }

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import org.opensearch.cluster.ClusterState;
+
+/**
+ * This class simulates methods normally called from OpenSearch ClusterService class.
+ */
+public class SDKClusterService {
+
+    private final ExtensionsRunner extensionsRunner;
+
+    /**
+     * Create an instance of this object.
+     *
+     * @param extensionsRunner An {@link ExtensionsRunner} instance.
+     */
+    public SDKClusterService(ExtensionsRunner extensionsRunner) {
+        this.extensionsRunner = extensionsRunner;
+    }
+
+    /**
+     * Send a request to OpenSearch to retrieve the cluster state
+     *
+     * @return the cluster state of OpenSearch
+     */
+    public ClusterState state() {
+        return extensionsRunner.sendClusterStateRequest(extensionsRunner.getExtensionTransportService());
+    }
+}

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -89,28 +89,13 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         );
     }
 
-    // test manager method invokes start on transport service
     @Test
-    public void testTransportServiceStarted() {
-
-        // verify mocked object interaction in manager method
+    public void testStartTransportService() {
         extensionsRunner.startTransportService(transportService);
+        // test manager method invokes start on transport service
         verify(transportService, times(1)).start();
-    }
-
-    // test manager method invokes accept incoming requests on transport service
-    @Test
-    public void testTransportServiceAcceptedIncomingRequests() {
-
-        // verify mocked object interaction in manager method
-        extensionsRunner.startTransportService(transportService);
-        verify(transportService, times(1)).acceptIncomingRequests();
-    }
-
-    @Test
-    public void testRegisterRequestHandler() {
-
-        extensionsRunner.startTransportService(transportService);
+        // cannot verify acceptIncomingRequests as it is a final method
+        // test registerRequestHandlers
         verify(transportService, times(5)).registerRequestHandler(anyString(), anyString(), anyBoolean(), anyBoolean(), any(), any());
     }
 

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class TestSDKClusterService extends OpenSearchTestCase {
+    private ExtensionsRunner extensionsRunner;
+    private SDKClusterService sdkClusterService;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        this.extensionsRunner = mock(ExtensionsRunner.class);
+        this.sdkClusterService = new SDKClusterService(extensionsRunner);
+    }
+
+    @Test
+    public void testState() throws Exception {
+        sdkClusterService.state();
+        verify(extensionsRunner, times(1)).getExtensionTransportService();
+
+        ArgumentCaptor<TransportService> argumentCaptor = ArgumentCaptor.forClass(TransportService.class);
+        verify(extensionsRunner, times(1)).sendClusterStateRequest(argumentCaptor.capture());
+        assertNull(argumentCaptor.getValue());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Creates a new `SDKClusterService` class intended to be a drop-in replacement for plugin migration.  By replacing constructor initialization of a `ClusterService` object with an instance of this class:
 - no code changes are needed for code containing `clusterService.state()` to work without changes.
 - `clusterService.getSettings().addSettingsUpdateConsumer(...)` becomes `clusterService.addSettingsUpdateConsumer(...)`

### Issues Resolved

Part of #160 supporting #283 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
