### PR TITLE
Parameterize SettingsUpdateConsumer to avoid need to cast

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -42,12 +42,13 @@ public class SDKClusterService {
 
     /**
      * Add a single settings update consumer to OpenSearch
+     * @param <T> The Type of the setting.
      *
      * @param setting The setting for which to consume updates.
      * @param consumer The consumer of the updates
      * @throws Exception if the registration of the consumer failed.
      */
-    public void addSettingsUpdateConsumer(Setting<?> setting, Consumer<?> consumer) throws Exception {
+    public <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer) throws Exception {
         addSettingsUpdateConsumer(Map.of(setting, consumer));
     }
 


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Improves on the `ClusterService` class committed in PR #344 by adding a type parameter indicating that the setting and consumer are the same type.

This avoids the need to cast the consumer type when there is only one pair of arguments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
