### PR TITLE
Move settings update consumers to new SDKClusterSettings class

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -21,6 +21,7 @@ import org.opensearch.common.settings.Setting;
 public class SDKClusterService {
 
     private final ExtensionsRunner extensionsRunner;
+    private final SDKClusterSettings clusterSettings;
 
     /**
      * Create an instance of this object.
@@ -29,6 +30,7 @@ public class SDKClusterService {
      */
     public SDKClusterService(ExtensionsRunner extensionsRunner) {
         this.extensionsRunner = extensionsRunner;
+        this.clusterSettings = new SDKClusterSettings();
     }
 
     /**
@@ -40,25 +42,35 @@ public class SDKClusterService {
         return extensionsRunner.sendClusterStateRequest(extensionsRunner.getExtensionTransportService());
     }
 
-    /**
-     * Add a single settings update consumer to OpenSearch
-     * @param <T> The Type of the setting.
-     *
-     * @param setting The setting for which to consume updates.
-     * @param consumer The consumer of the updates
-     * @throws Exception if the registration of the consumer failed.
-     */
-    public <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer) throws Exception {
-        addSettingsUpdateConsumer(Map.of(setting, consumer));
+    public SDKClusterSettings getClusterSettings() {
+        return clusterSettings;
     }
 
     /**
-     * Add multiple settings update consumers to OpenSearch
-     *
-     * @param settingUpdateConsumers A map of Setting to Consumer.
-     * @throws Exception if the registration of the consumers failed.
+     * This class simulates methods normally called from OpenSearch ClusterSettings class.
      */
-    public void addSettingsUpdateConsumer(Map<Setting<?>, Consumer<?>> settingUpdateConsumers) throws Exception {
-        extensionsRunner.sendAddSettingsUpdateConsumerRequest(extensionsRunner.getExtensionTransportService(), settingUpdateConsumers);
+    public class SDKClusterSettings {
+
+        /**
+         * Add a single settings update consumer to OpenSearch
+         * @param <T> The Type of the setting.
+         *
+         * @param setting The setting for which to consume updates.
+         * @param consumer The consumer of the updates
+         * @throws Exception if the registration of the consumer failed.
+         */
+        public <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer) throws Exception {
+            addSettingsUpdateConsumer(Map.of(setting, consumer));
+        }
+
+        /**
+         * Add multiple settings update consumers to OpenSearch
+         *
+         * @param settingUpdateConsumers A map of Setting to Consumer.
+         * @throws Exception if the registration of the consumers failed.
+         */
+        public void addSettingsUpdateConsumer(Map<Setting<?>, Consumer<?>> settingUpdateConsumers) throws Exception {
+            extensionsRunner.sendAddSettingsUpdateConsumerRequest(extensionsRunner.getExtensionTransportService(), settingUpdateConsumers);
+        }
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.TransportService;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -46,10 +48,15 @@ public class TestSDKClusterService extends OpenSearchTestCase {
     }
 
     @Test
+    public void testGetClusterSettings() {
+        assertInstanceOf(SDKClusterSettings.class, sdkClusterService.getClusterSettings());
+    }
+
+    @Test
     public void testAddSettingsUpdateConsumer() throws Exception {
         Setting<Boolean> boolSetting = Setting.boolSetting("test", false);
         Consumer<Boolean> boolConsumer = b -> {};
-        sdkClusterService.addSettingsUpdateConsumer(boolSetting, boolConsumer);
+        sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(boolSetting, boolConsumer);
         verify(extensionsRunner, times(1)).getExtensionTransportService();
 
         ArgumentCaptor<TransportService> transportServiceArgumentCaptor = ArgumentCaptor.forClass(TransportService.class);


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Moves the settings update consumer calls to a `SDKClusterSettings` class to better match current extension existing code and tests.

### Issues Resolved

Part of #353

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
