### PR TITLE
Update dev guide from _opensearch-sdk-1 to _opensearch-sdk-java-1 in example curl command

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -188,7 +188,7 @@ It is important that the OpenSearch SDK for Java is already up and running on a 
 
 The following request is configured to be handled by the sample `HelloWorldExtension` (note the matching uniqueId):
 ```
-curl -X GET localhost:9200/_extensions/_opensearch-sdk-1/hello
+curl -X GET localhost:9200/_extensions/_opensearch-sdk-java-1/hello
 ```
 
 ## Run Tests


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The example curl command in the developer guide still uses the legacy `_opensearch-sdk-1` route from before this repo was renamed to `opensearch-sdk-java`. The example `extensions.yml` file uses `opensearch-sdk-java-1` so the curl should match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
