### PR TITLE
Add new workflow to automatically add 'backport 1.x' label on main branch PR's

### DIFF
--- a/.github/workflows/add_backport_label.yml
+++ b/.github/workflows/add_backport_label.yml
@@ -1,0 +1,15 @@
+name: Add Backport Label
+
+on:
+  branches: main
+  pull_request:
+    types: opened
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: backport 1.x


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Adds a new workflow that will automatically add the `backport 1.x` label to all PR's opened on the main branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
