### PR TITLE
Fix add backport label workflow syntax

### DIFF
--- a/.github/workflows/add_backport_label.yml
+++ b/.github/workflows/add_backport_label.yml
@@ -1,8 +1,7 @@
 name: Add Backport Label
-
 on:
-  branches: main
-  pull_request:
+  pull_request_target:
+    branches: main
     types: opened
 
 jobs:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

1. The `branches` filter does not apply to the `on` triggering events and is causing [failed workflows](https://github.com/opensearch-project/opensearch-sdk-java/actions/workflows/add_backport_label.yml). Moved it to where it needs to be.
2. The `pull_request` event fails the labeling with a "Resource not accessible by integration" because the new workflow can't run from my fork. Switched it to `pull_request_target` which runs from SDK branch.  It won't run on this PR (by design) but once this PR is merged it will begin running on other PRs.
3. Changed the version for `tibdex/github-app-token` to major version only so we don't need to update each minor version release.  Closed #395 as unneeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
