### PR TITLE
Change 1.x branch to pull from 2.6 snapshot and revert 'Migrate client transports to Apache HttpClient/Core5.x'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ configurations {
 
 dependencies {
 
-    def opensearchVersion = "2.6.0-SNAPSHOT"
+    def opensearchVersion = "2.+"
     def log4jVersion = "2.19.0"
     def nettyVersion = "4.1.87.Final"
     def luceneVersion = "9.4.2"

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ configurations {
 dependencies {
 
     def opensearchVersion = "2.+"
+    def opensearchJavaClientVersion = "2.1.0-SNAPSHOT"
     def log4jVersion = "2.19.0"
     def nettyVersion = "4.1.87.Final"
     def luceneVersion = "9.4.2"
@@ -92,7 +93,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
     implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}")
     implementation("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
-    implementation("org.opensearch.client:opensearch-java:2.1.0-SNAPSHOT")
+    implementation("org.opensearch.client:opensearch-java:${opensearchJavaClientVersion}")
     implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation("io.netty:netty-all:${nettyVersion}")
     implementation("org.apache.lucene:lucene-core:${luceneVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ configurations {
 
 dependencies {
 
-    def opensearchVersion = "3.0.0-SNAPSHOT"
+    def opensearchVersion = "2.6.0-SNAPSHOT"
     def log4jVersion = "2.19.0"
     def nettyVersion = "4.1.87.Final"
     def luceneVersion = "9.4.2"
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
     implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}")
     implementation("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
-    implementation("org.opensearch.client:opensearch-java:${opensearchVersion}")
+    implementation("org.opensearch.client:opensearch-java:3.0.0-SNAPSHOT")
     implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation("io.netty:netty-all:${nettyVersion}")
     implementation("org.apache.lucene:lucene-core:${luceneVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
     implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}")
     implementation("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
-    implementation("org.opensearch.client:opensearch-java:3.0.0-SNAPSHOT")
+    implementation("org.opensearch.client:opensearch-java:2.1.0-SNAPSHOT")
     implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation("io.netty:netty-all:${nettyVersion}")
     implementation("org.apache.lucene:lucene-core:${luceneVersion}")

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -104,7 +104,7 @@ public class SDKClient implements Closeable {
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         // Create Client
-        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper(mapper));
         javaClient = new OpenSearchClient(transport);
         return javaClient;
     }

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -113,8 +113,8 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
             "opensearch-sdk-1",
             sourceNode.getAddress(),
             new HashMap<String, String>(),
-            Version.fromString("3.0.0"),
-            Version.fromString("3.0.0"),
+            Version.fromString("2.6.0"),
+            Version.fromString("2.6.0"),
             new ArrayList<ExtensionDependency>()
         );
 

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -113,8 +113,8 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
             "opensearch-sdk-1",
             sourceNode.getAddress(),
             new HashMap<String, String>(),
-            Version.fromString("2.6.0"),
-            Version.fromString("2.6.0"),
+            Version.CURRENT,
+            Version.CURRENT,
             new ArrayList<ExtensionDependency>()
         );
 


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
These changes enable the 1.x branch of opensearch-sdk-java to be compatible with the 2.x branch of OpenSearch


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
