### PR TITLE
Add sample for validator

### DIFF
--- a/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
@@ -22,19 +22,11 @@ public class ExampleCustomSettingConfig {
     /**
      * A string setting, if the string setting match the FORBIDDEN_REGEX string, the validation will be fail.
      */
-    static final Setting<String> VALIDATED_SETTING = Setting.simpleString(
+    public static final Setting<String> VALIDATED_SETTING = Setting.simpleString(
         "custom.validated",
         new RegexValidator(FORBIDDEN_REGEX),
         Property.NodeScope,
         Property.Dynamic
     );
 
-    /**
-     * For testing
-     *
-     * @return the custom.validated value
-     */
-    public static Setting<String> getValidated() {
-        return VALIDATED_SETTING;
-    }
 }

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.RegexValidator;
+import org.opensearch.common.settings.Setting.Property;
+
+/**
+ * {@link ExampleCustomSettingConfig} contains the custom settings value and their static declarations.
+ */
+public class ExampleCustomSettingConfig {
+    private static final String FORBIDDEN_REGEX = "forbidden";
+    private final String validated;
+
+    /**
+     * A string setting, if the string setting match the FORBIDDEN_REGEX string, the validation will be fail.
+     */
+    static final Setting<String> VALIDATED_SETTING = Setting.simpleString(
+        "custom.validated",
+        new RegexValidator(FORBIDDEN_REGEX),
+        Property.NodeScope,
+        Property.Dynamic
+    );
+
+    /**
+     * Gets the value of the custom.validated String setting.
+     *
+     * @return the custom.validated value
+     */
+    public String getValidated() {
+        return validated;
+    }
+}

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
@@ -30,11 +30,11 @@ public class ExampleCustomSettingConfig {
     );
 
     /**
-     * Gets the value of the custom.validated String setting.
+     * For testing
      *
      * @return the custom.validated value
      */
-    public String getValidated() {
-        return validated;
+    public static Setting<String> getValidated() {
+        return VALIDATED_SETTING;
     }
 }

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
@@ -18,7 +18,6 @@ import org.opensearch.common.settings.Setting.Property;
  */
 public class ExampleCustomSettingConfig {
     private static final String FORBIDDEN_REGEX = "forbidden";
-    private final String validated;
 
     /**
      * A string setting, if the string setting match the FORBIDDEN_REGEX string, the validation will be fail.

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/ExampleCustomSettingConfig.java
@@ -20,10 +20,10 @@ public class ExampleCustomSettingConfig {
     private static final String FORBIDDEN_REGEX = "forbidden";
 
     /**
-     * A string setting, if the string setting match the FORBIDDEN_REGEX string, the validation will be fail.
+     * A string setting. If the string setting matches the FORBIDDEN_REGEX string, the validation will fail.
      */
     public static final Setting<String> VALIDATED_SETTING = Setting.simpleString(
-        "custom.validated",
+        "custom.validate",
         new RegexValidator(FORBIDDEN_REGEX),
         Property.NodeScope,
         Property.Dynamic

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -16,7 +16,6 @@ import java.util.List;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.common.settings.Setting;
-import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.sdk.BaseExtension;
 import org.opensearch.sdk.Extension;
 import org.opensearch.sdk.ExtensionRestHandler;
@@ -43,7 +42,6 @@ public class HelloWorldExtension extends BaseExtension implements ActionExtensio
      * Optional classpath-relative path to a yml file containing extension settings.
      */
     private static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
-    private static final String FORBIDDEN_REGEX = "forbidden";
 
     /**
      * Instantiate this extension, initializing the connection settings and REST actions.
@@ -66,14 +64,11 @@ public class HelloWorldExtension extends BaseExtension implements ActionExtensio
         return Arrays.asList(new ActionHandler<>(SampleAction.INSTANCE, SampleTransportAction.class));
     }
 
-    Setting<String> VALIDATED_SETTING = Setting.simpleString("custom.validated", value -> {
-        if (isForbiddenPresent(value)) {
-            throw new IllegalArgumentException("Setting must not contain [forbidden]");
-        }
-    }, Property.NodeScope, Property.Dynamic);
-
-    private boolean isForbiddenPresent(String input) {
-        return Setting.RegexValidator.validate(input, FORBIDDEN_REGEX);
+    /**
+     * A list of object that includes a single instance of Validator for Custom Setting
+     */
+    public List<Setting<?>> getSettings() {
+        return Arrays.asList(ExampleCustomSettingConfig.VALIDATED_SETTING);
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -15,6 +15,8 @@ import java.util.List;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.sdk.BaseExtension;
 import org.opensearch.sdk.Extension;
 import org.opensearch.sdk.ExtensionRestHandler;
@@ -41,6 +43,7 @@ public class HelloWorldExtension extends BaseExtension implements ActionExtensio
      * Optional classpath-relative path to a yml file containing extension settings.
      */
     private static final String EXTENSION_SETTINGS_PATH = "/sample/helloworld-settings.yml";
+    private static final String FORBIDDEN_REGEX = "forbidden";
 
     /**
      * Instantiate this extension, initializing the connection settings and REST actions.
@@ -61,6 +64,16 @@ public class HelloWorldExtension extends BaseExtension implements ActionExtensio
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Arrays.asList(new ActionHandler<>(SampleAction.INSTANCE, SampleTransportAction.class));
+    }
+
+    Setting<String> VALIDATED_SETTING = Setting.simpleString("custom.validated", value -> {
+        if (isForbiddenPresent(value)) {
+            throw new IllegalArgumentException("Setting must not contain [forbidden]");
+        }
+    }, Property.NodeScope, Property.Dynamic);
+
+    private boolean isForbiddenPresent(String input) {
+        return Setting.RegexValidator.validate(input, FORBIDDEN_REGEX);
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -25,10 +25,6 @@ import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.settings.Setting;
-import org.opensearch.common.settings.Setting.Property;
-import org.opensearch.common.settings.Setting.RegexValidator;
-import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
@@ -243,6 +239,7 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
 
         assertEquals("failed to find action [" + UnregisteredAction.INSTANCE + "] to execute", ex.getMessage());
     }
+
     public void testValidatedSettings() {
         final String expected = randomAlphaOfLengthBetween(1, 5);
         final String actual = VALIDATED_SETTING.get(Settings.builder().put(VALIDATED_SETTING.getKey(), expected).build());

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -28,6 +28,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Setting.RegexValidator;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
@@ -46,6 +47,8 @@ import org.opensearch.threadpool.ThreadPool;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+
+import static org.opensearch.sdk.sample.helloworld.ExampleCustomSettingConfig.VALIDATED_SETTING;
 
 public class TestHelloWorldExtension extends OpenSearchTestCase {
 
@@ -241,14 +244,14 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
         assertEquals("failed to find action [" + UnregisteredAction.INSTANCE + "] to execute", ex.getMessage());
     }
     public void testValidatedSettings() {
-        Setting<String> expectedSetting = Setting.simpleString(
-            "custom.validated",
-            new RegexValidator("forbidden"),
-            Property.NodeScope,
-            Property.Dynamic
-        );
-        Setting<String> extensionValidatedSetting = ExampleCustomSettingConfig.getValidated();
-        assertEquals(expectedSetting, extensionValidatedSetting);
-    }
+        final String expected = randomAlphaOfLengthBetween(1, 5);
+        final String actual = VALIDATED_SETTING.get(Settings.builder().put(VALIDATED_SETTING.getKey(), expected).build());
+        assertEquals(expected, actual);
 
+        final IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> VALIDATED_SETTING.get(Settings.builder().put("custom.validated", "it's forbidden").build())
+        );
+        assertEquals("Setting must not contain [forbidden]", exception.getMessage());
+    }
 }

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -25,6 +25,9 @@ import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.settings.Setting.RegexValidator;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
@@ -237,4 +240,15 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
 
         assertEquals("failed to find action [" + UnregisteredAction.INSTANCE + "] to execute", ex.getMessage());
     }
+    public void testValidatedSettings() {
+        Setting<String> expectedSetting = Setting.simpleString(
+            "custom.validated",
+            new RegexValidator("forbidden"),
+            Property.NodeScope,
+            Property.Dynamic
+        );
+        Setting<String> extensionValidatedSetting = ExampleCustomSettingConfig.getValidated();
+        assertEquals(expectedSetting, extensionValidatedSetting);
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Frank Lou <mloufra@amazon.com>

### Description
Create a sample Setting in Hello World Extension package, and using the RegexValidator form the Setting on Opensearch side the validate the value of sample Setting.

Needs [OS #6221](https://github.com/opensearch-project/OpenSearch/pull/6221) to be merged first.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/350

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
