### PR TITLE
Create ActionExtension Interface

### DIFF
--- a/src/main/java/org/opensearch/sdk/ActionExtension.java
+++ b/src/main/java/org/opensearch/sdk/ActionExtension.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionResponse;
+import org.opensearch.action.RequestValidators;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.action.support.TransportActions;
+import org.opensearch.common.Strings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.rest.RestHeaderDefinition;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+/**
+ * An additional extension point for {@link Extension}s that extends OpenSearch's scripting functionality. Implement it like this:
+ * <pre>{@code
+ *   {@literal @}Override
+ *   public List<ActionHandler<?, ?>> getActions() {
+ *       return Arrays.asList(new ActionHandler<>(ReindexAction.INSTANCE, TransportReindexAction.class),
+ *               new ActionHandler<>(UpdateByQueryAction.INSTANCE, TransportUpdateByQueryAction.class),
+ *               new ActionHandler<>(DeleteByQueryAction.INSTANCE, TransportDeleteByQueryAction.class),
+ *               new ActionHandler<>(RethrottleAction.INSTANCE, TransportRethrottleAction.class));
+ *   }
+ * }</pre>
+ */
+public interface ActionExtension {
+    /**
+     * Actions added by this extension.
+     */
+    default List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Client actions added by this extension. This defaults to all of the {@linkplain ActionType} in
+     * {@linkplain ActionExtension#getActions()}.
+     */
+    default List<ActionType<? extends ActionResponse>> getClientActions() {
+        return getActions().stream().map(a -> a.action).collect(Collectors.toList());
+    }
+
+    /**
+     * ActionType filters added by this extension.
+     */
+    default List<ActionFilter> getActionFilters() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Gets a list of {@link ExtensionRestHandler} implementations this extension handles.
+     *
+     * @return a list of REST handlers (REST actions) this extension handles.
+     */
+    default List<ExtensionRestHandler> getExtensionRestHandlers() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns headers which should be copied through rest requests on to internal requests.
+     */
+    default Collection<RestHeaderDefinition> getRestHeaders() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns headers which should be copied from internal requests into tasks.
+     */
+    default Collection<String> getTaskHeaders() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a function used to wrap each rest request before handling the request.
+     * The returned {@link UnaryOperator} is called for every incoming rest request and receives
+     * the original rest handler as it's input. This allows adding arbitrary functionality around
+     * rest request handlers to do for instance logging or authentication.
+     * A simple example of how to only allow GET request is here:
+     * <pre>
+     * {@code
+     *    UnaryOperator<ExtensionRestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+     *      return originalHandler -> (RestHandler) (request) -> {
+     *        if (request.method() != Method.GET) {
+     *          throw new IllegalStateException("only GET requests are allowed");
+     *        }
+     *        originalHandler.handleRequest(request);
+     *      };
+     *    }
+     * }
+     * </pre>
+     */
+    default UnaryOperator<ExtensionRestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+        return null;
+    }
+
+    /**
+     * Class responsible for handing Transport Actions
+     */
+    final class ActionHandler<Request extends ActionRequest, Response extends ActionResponse> {
+        private final ActionType<Response> action;
+        private final Class<? extends TransportAction<Request, Response>> transportAction;
+        private final Class<?>[] supportTransportActions;
+
+        /**
+         * Create a record of an action, the {@linkplain TransportAction} that handles it, and any supporting {@linkplain TransportActions}
+         * that are needed by that {@linkplain TransportAction}.
+         */
+        public ActionHandler(
+            ActionType<Response> action,
+            Class<? extends TransportAction<Request, Response>> transportAction,
+            Class<?>... supportTransportActions
+        ) {
+            this.action = action;
+            this.transportAction = transportAction;
+            this.supportTransportActions = supportTransportActions;
+        }
+
+        public ActionType<Response> getAction() {
+            return action;
+        }
+
+        public Class<? extends TransportAction<Request, Response>> getTransportAction() {
+            return transportAction;
+        }
+
+        public Class<?>[] getSupportTransportActions() {
+            return supportTransportActions;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder b = new StringBuilder().append(action.name()).append(" is handled by ").append(transportAction.getName());
+            if (supportTransportActions.length > 0) {
+                b.append('[').append(Strings.arrayToCommaDelimitedString(supportTransportActions)).append(']');
+            }
+            return b.toString();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == null || obj.getClass() != ActionHandler.class) {
+                return false;
+            }
+            ActionHandler<?, ?> other = (ActionHandler<?, ?>) obj;
+            return Objects.equals(action, other.action)
+                && Objects.equals(transportAction, other.transportAction)
+                && Objects.deepEquals(supportTransportActions, other.supportTransportActions);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(action, transportAction, supportTransportActions);
+        }
+    }
+
+    /**
+     * Returns a collection of validators that are used by {@link RequestValidators} to validate a
+     * {@link org.opensearch.action.admin.indices.mapping.put.PutMappingRequest} before the executing it.
+     */
+    default Collection<RequestValidators.RequestValidator<PutMappingRequest>> mappingRequestValidators() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns a collection of validators that are used by {@link RequestValidators} to validate a
+     * {@link org.opensearch.action.admin.indices.alias.IndicesAliasesRequest} before the executing it.
+     */
+    default Collection<RequestValidators.RequestValidator<IndicesAliasesRequest>> indicesAliasesRequestValidators() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -19,7 +19,7 @@ import org.opensearch.threadpool.ThreadPool;
 /**
  * An abstract class that provides sample methods required by extensions
  */
-public abstract class BaseExtension implements Extension {
+public abstract class BaseExtension implements Extension, ActionExtension {
     /**
      * The {@link ExtensionsRunner} instance running this extension
      */

--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -40,15 +40,6 @@ public interface Extension {
     ExtensionSettings getExtensionSettings();
 
     /**
-     * Gets a list of {@link ExtensionRestHandler} implementations this extension handles.
-     *
-     * @return a list of REST handlers (REST actions) this extension handles.
-     */
-    default List<ExtensionRestHandler> getExtensionRestHandlers() {
-        return Collections.emptyList();
-    }
-
-    /**
      * Gets an optional list of custom {@link Setting} for the extension to register with OpenSearch.
      *
      * @return a list of custom settings this extension uses.
@@ -81,14 +72,18 @@ public interface Extension {
      * @param threadPool A service to allow retrieving an executor to run an async action
      * @return A collection of objects
      */
-    Collection<Object> createComponents(SDKClient client, ClusterService clusterService, ThreadPool threadPool);
+    default Collection<Object> createComponents(SDKClient client, ClusterService clusterService, ThreadPool threadPool) {
+        return Collections.emptyList();
+    }
 
     /**
      * Gets an optional list of custom {@link TransportAction} for the extension to register with OpenSearch.
+     * <p>
+     * TODO: ActionExtension#getActions will replace this: https://github.com/opensearch-project/opensearch-sdk-java/issues/368
      *
      * @return a list of custom transport actions this extension uses.
      */
-    default Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> getActions() {
+    default Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> getActionsMap() {
         return Collections.emptyMap();
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -138,18 +138,21 @@ public class ExtensionsRunner {
             .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress())
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
             .build();
-        // store REST handlers in the registry
-        for (ExtensionRestHandler extensionRestHandler : extension.getExtensionRestHandlers()) {
-            for (Route route : extensionRestHandler.routes()) {
-                extensionRestPathRegistry.registerHandler(route.getMethod(), route.getPath(), extensionRestHandler);
+        if (extension instanceof ActionExtension) {
+            // store REST handlers in the registry
+            for (ExtensionRestHandler extensionRestHandler : ((ActionExtension) extension).getExtensionRestHandlers()) {
+                for (Route route : extensionRestHandler.routes()) {
+                    extensionRestPathRegistry.registerHandler(route.getMethod(), route.getPath(), extensionRestHandler);
+                }
             }
+            // TODO new getActions code will go here
         }
         // save custom settings
         this.customSettings = extension.getSettings();
         // save custom namedXContent
         this.customNamedXContent = extension.getNamedXContent();
         // save custom transport actions
-        this.transportActions = new TransportActions(extension.getActions());
+        this.transportActions = new TransportActions(extension.getActionsMap());
 
         ThreadPool threadPool = new ThreadPool(this.getSettings());
 

--- a/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
+++ b/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
@@ -10,8 +10,6 @@
 package org.opensearch.sdk;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * An Extension Runner for testing using test settings.
@@ -25,13 +23,7 @@ public class ExtensionsRunnerForTest extends ExtensionsRunner {
      */
     public ExtensionsRunnerForTest() throws IOException {
         super(new BaseExtension(new ExtensionSettings("sample-extension", "127.0.0.1", "4532", "127.0.0.1", "9200")) {
-
-            @Override
-            public List<ExtensionRestHandler> getExtensionRestHandlers() {
-                return Collections.emptyList();
-            }
         });
-
     }
 
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TestExtensionInterfaces extends OpenSearchTestCase {
+
+    @Test
+    void testExtension() {
+        Extension extension = new Extension() {
+            @Override
+            public ExtensionSettings getExtensionSettings() {
+                return null;
+            }
+
+            @Override
+            public void setExtensionsRunner(ExtensionsRunner extensionsRunner) {}
+        };
+
+        assertTrue(extension.getSettings().isEmpty());
+        assertTrue(extension.getNamedXContent().isEmpty());
+        assertTrue(extension.createComponents(null, null, null).isEmpty());
+        assertTrue(extension.getExecutorBuilders(Settings.EMPTY).isEmpty());
+    }
+
+    @Test
+    void testActionExtension() {
+        ActionExtension actionExtension = new ActionExtension() {
+        };
+
+        assertTrue(actionExtension.getActions().isEmpty());
+        assertTrue(actionExtension.getClientActions().isEmpty());
+        assertTrue(actionExtension.getActionFilters().isEmpty());
+        assertTrue(actionExtension.getExtensionRestHandlers().isEmpty());
+        assertTrue(actionExtension.getRestHeaders().isEmpty());
+        assertTrue(actionExtension.getTaskHeaders().isEmpty());
+        assertDoesNotThrow(() -> actionExtension.getRestHandlerWrapper(null));
+        assertTrue(actionExtension.indicesAliasesRequestValidators().isEmpty());
+        assertTrue(actionExtension.mappingRequestValidators().isEmpty());
+    }
+
+    @Test
+    void testEngineExtension() {
+        EngineExtension engineExtension = new EngineExtension() {
+        };
+
+        assertTrue(engineExtension.getEngineFactory(null).isEmpty());
+        assertTrue(engineExtension.getCustomCodecServiceFactory(null).isEmpty());
+        assertTrue(engineExtension.getCustomTranslogDeletionPolicyFactory().isEmpty());
+    }
+
+    @Test
+    void testESearchExtension() {
+        SearchExtension searchExtension = new SearchExtension() {
+        };
+
+        assertTrue(searchExtension.getScoreFunctions().isEmpty());
+        assertTrue(searchExtension.getSignificanceHeuristics().isEmpty());
+        assertTrue(searchExtension.getMovingAverageModels().isEmpty());
+        assertTrue(searchExtension.getFetchSubPhases(null).isEmpty());
+        assertTrue(searchExtension.getSearchExts().isEmpty());
+        assertTrue(searchExtension.getHighlighters().isEmpty());
+        assertTrue(searchExtension.getSuggesters().isEmpty());
+        assertTrue(searchExtension.getQueries().isEmpty());
+        assertTrue(searchExtension.getSorts().isEmpty());
+        assertTrue(searchExtension.getAggregations().isEmpty());
+        assertTrue(searchExtension.getAggregationExtentions().isEmpty());
+        assertTrue(searchExtension.getCompositeAggregations().isEmpty());
+        assertTrue(searchExtension.getPipelineAggregations().isEmpty());
+        assertTrue(searchExtension.getRescorers().isEmpty());
+        assertTrue(searchExtension.getQueryPhaseSearcher().isEmpty());
+        assertTrue(searchExtension.getIndexSearcherExecutorProvider().isEmpty());
+    }
+}

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.sdk.ActionExtension;
 import org.opensearch.sdk.Extension;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.sdk.ExtensionSettings;
@@ -42,7 +43,7 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
 
     @Test
     public void testExtensionRestHandlers() {
-        List<ExtensionRestHandler> extensionRestHandlers = extension.getExtensionRestHandlers();
+        List<ExtensionRestHandler> extensionRestHandlers = ((ActionExtension) extension).getExtensionRestHandlers();
         assertEquals(1, extensionRestHandlers.size());
         List<Route> routes = extensionRestHandlers.get(0).routes();
         assertEquals(4, routes.size());


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Adds the `ActionExtension` interface.
 - moves the `getRestHandlers()` method there (where it belongs) from `Extension`
 - creates `getActions()` on that interface with the same signature as the plugin (for migration purposes).
   - changes `getActions()` on the `Extension` interface with a different signature to `getActionsMap()` as a temporary measure (to prevent same-name conflict) until the code in `ExtensionsRunner` is updated with an improved `getActions()` implementation as part of #368
 - adds inheritance to the `HelloWorldExtension` class
 - removes the default `getRestHandlers()` implementation in the ExtensionsRunnerForTest class
 - in ExtensionsRunner where the `getRestHandlers()` extension point is called, adds a conditional check whether the extension is an instanceof ActionExtension

Additional changes
 - Adds tests for default methods currently implemented extension interfaces
 - adds default implementation for `createComponents()`

### Issues Resolved
Closes #320 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
