### PR TITLE
Remove unnecessary exception throwing for settings update consumers

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -472,37 +472,32 @@ public class ExtensionsRunner {
      *
      * @param transportService  The TransportService defining the connection to OpenSearch.
      * @param settingUpdateConsumers A map of setting objects and their corresponding consumers
-     * @throws Exception if there are no setting update consumers within the settingUpdateConsumers map
      */
-    public void sendAddSettingsUpdateConsumerRequest(TransportService transportService, Map<Setting<?>, Consumer<?>> settingUpdateConsumers)
-        throws Exception {
-        logger.info("Sending Add Settings Update Consumer request to OpenSearch");
-
+    public void sendAddSettingsUpdateConsumerRequest(
+        TransportService transportService,
+        Map<Setting<?>, Consumer<?>> settingUpdateConsumers
+    ) {
         // Determine if there are setting update consumers to be registered
-        if (settingUpdateConsumers.isEmpty()) {
-            throw new Exception("There are no setting update consumers to be registered");
-        } else {
-
+        if (!settingUpdateConsumers.isEmpty()) {
             // Register setting update consumers to UpdateSettingsRequestHandler
             this.updateSettingsRequestHandler.registerSettingUpdateConsumer(settingUpdateConsumers);
 
             // Extract registered settings from setting update consumer map
             List<Setting<?>> componentSettings = new ArrayList<>(settingUpdateConsumers.size());
             componentSettings.addAll(settingUpdateConsumers.keySet());
+            logger.info(
+                "Sending Add Settings Update Consumer request to OpenSearch for {}",
+                componentSettings.stream().map(Setting::getKey).toArray()
+            );
 
             AcknowledgedResponseHandler acknowledgedResponseHandler = new AcknowledgedResponseHandler();
-            try {
-                transportService.sendRequest(
-                    opensearchNode,
-                    ExtensionsManager.REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER,
-                    new AddSettingsUpdateConsumerRequest(this.extensionNode, componentSettings),
-                    acknowledgedResponseHandler
-                );
-            } catch (Exception e) {
-                logger.info("Failed to send Add Settings Update Consumer request to OpenSearch", e);
-            }
+            transportService.sendRequest(
+                opensearchNode,
+                ExtensionsManager.REQUEST_EXTENSION_ADD_SETTINGS_UPDATE_CONSUMER,
+                new AddSettingsUpdateConsumerRequest(this.extensionNode, componentSettings),
+                acknowledgedResponseHandler
+            );
         }
-
     }
 
     private Settings getSettings() {

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -57,9 +57,8 @@ public class SDKClusterService {
          *
          * @param setting The setting for which to consume updates.
          * @param consumer The consumer of the updates
-         * @throws Exception if the registration of the consumer failed.
          */
-        public <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer) throws Exception {
+        public <T> void addSettingsUpdateConsumer(Setting<T> setting, Consumer<T> consumer) {
             addSettingsUpdateConsumer(Map.of(setting, consumer));
         }
 
@@ -67,9 +66,8 @@ public class SDKClusterService {
          * Add multiple settings update consumers to OpenSearch
          *
          * @param settingUpdateConsumers A map of Setting to Consumer.
-         * @throws Exception if the registration of the consumers failed.
          */
-        public void addSettingsUpdateConsumer(Map<Setting<?>, Consumer<?>> settingUpdateConsumers) throws Exception {
+        public void addSettingsUpdateConsumer(Map<Setting<?>, Consumer<?>> settingUpdateConsumers) {
             extensionsRunner.sendAddSettingsUpdateConsumerRequest(extensionsRunner.getExtensionTransportService(), settingUpdateConsumers);
         }
     }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

`sendAddSettingsUpdateConsumerRequest()` was throwing an `Exception` (checked) for an empty map.  This required callers to handle the exception.

This was unnecessary as an unchecked `IllegalArgumentException` would have been a better type to use.  Actual exceptions during the call are handled by the response handler which logs them.

I went further and just ignored the empty map case and made it a no-op.  Happy to put an IllegalArgumentExxception back in if reviewers think it's needed.

### Issues Resolved

Fixes #422. (After merge, will submit a PR on AD repo to take advantage of no need for handling.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
