### PR TITLE
Simplify client creation by passing settings

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -112,7 +112,18 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Creates OpenSearchClient for SDK. It also creates a restClient as a wrapper around Java OpenSearchClient
+     * Initializes an OpenSearchClient using OpenSearch JavaClient
+     *
+     * @param settings The Extension settings
+     * @return The SDKClient implementation of OpenSearchClient. The user is responsible for calling
+     *         {@link #doCloseJavaClient()} when finished with the client
+     */
+    public OpenSearchClient initializeJavaClient(ExtensionSettings settings) {
+        return initializeJavaClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
+    }
+
+    /**
+     * Initializes an OpenSearchClient using OpenSearch JavaClient
      *
      * @param hostAddress The address of OpenSearch cluster, client can connect to
      * @param port        The port of OpenSearch cluster
@@ -135,6 +146,25 @@ public class SDKClient implements Closeable {
         OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper(mapper));
         javaClient = new OpenSearchClient(transport);
         return javaClient;
+    }
+
+    /**
+     * Initializes a SDK Rest Client wrapping the {@link RestHighLevelClient}.
+     * <p>
+     * The purpose of this client is to provide a drop-in replacement for the syntax of the {@link Client}
+     * implementation in existing plugins with a minimum of code changes.
+     * <p>
+     * Do not use this client for new development.
+     *
+     * @param settings The Extension settings
+     * @return The SDKClient implementation of RestHighLevelClient. The user is responsible for calling
+     *         {@link #doCloseHighLevelClient()} when finished with the client
+     * @deprecated Provided for compatibility with existing plugins to permit migration. Use
+     *             {@link #initializeJavaClient} for new development.
+     */
+    @Deprecated
+    public SDKRestClient initializeRestClient(ExtensionSettings settings) {
+        return initializeRestClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 @SuppressWarnings("deprecation")
 public class TestSDKClient extends OpenSearchTestCase {
     private SDKClient sdkClient;
+    private final ExtensionSettings settings = new ExtensionSettings("", "", "", "localhost", "9200");
 
     @Override
     @BeforeEach
@@ -50,7 +51,7 @@ public class TestSDKClient extends OpenSearchTestCase {
 
     @Test
     public void testCreateJavaClient() throws Exception {
-        OpenSearchClient javaClient = sdkClient.initializeJavaClient("localhost", 9200);
+        OpenSearchClient javaClient = sdkClient.initializeJavaClient(settings);
         assertInstanceOf(OpenSearchIndicesClient.class, javaClient.indices());
         assertInstanceOf(OpenSearchClusterClient.class, javaClient.cluster());
 
@@ -59,7 +60,7 @@ public class TestSDKClient extends OpenSearchTestCase {
 
     @Test
     public void testCreateRestClient() throws Exception {
-        SDKRestClient restClient = sdkClient.initializeRestClient("localhost", 9200);
+        SDKRestClient restClient = sdkClient.initializeRestClient(settings);
         assertInstanceOf(SDKIndicesClient.class, restClient.indices());
         assertInstanceOf(SDKClusterAdminClient.class, restClient.cluster());
         assertEquals(restClient, restClient.admin());
@@ -69,7 +70,7 @@ public class TestSDKClient extends OpenSearchTestCase {
 
     @Test
     public void testSDKRestClient() throws Exception {
-        SDKRestClient restClient = sdkClient.initializeRestClient("localhost", 9200);
+        SDKRestClient restClient = sdkClient.initializeRestClient(settings);
 
         // Would really prefer to mock/verify the method calls but they are final
         assertDoesNotThrow(() -> restClient.index(new IndexRequest(), ActionListener.wrap(r -> {}, e -> {})));
@@ -83,7 +84,7 @@ public class TestSDKClient extends OpenSearchTestCase {
 
     @Test
     public void testSDKIndicesClient() throws Exception {
-        SDKRestClient restClient = sdkClient.initializeRestClient("localhost", 9200);
+        SDKRestClient restClient = sdkClient.initializeRestClient(settings);
         SDKIndicesClient indicesClient = restClient.indices();
 
         // Would really prefer to mock/verify the method calls but the IndicesClient class is final
@@ -106,5 +107,4 @@ public class TestSDKClient extends OpenSearchTestCase {
         super.tearDown();
         this.sdkClient.close();
     }
-
 }


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

Simplifies the process of creating a SDK Java or Rest client with an overloaded constructor allowing an extension to pass its settings to the constructor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
