### PR TITLE
Replace jackson YAML reading with snakeyaml

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -107,7 +107,6 @@ public class ExtensionSettings {
         }
         try (InputStream inputStream = Files.newInputStream(Path.of(resource.toURI()))) {
             Map<String, Object> extensionMap = yaml.load(inputStream);
-            inputStream.close();
             if (extensionMap == null) {
                 throw new IOException("extension.yml is empty");
             }

--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -9,12 +9,16 @@
 
 package org.opensearch.sdk;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * This class encapsulates the settings for an Extension.
@@ -96,12 +100,26 @@ public class ExtensionSettings {
      * @throws IOException if there is an error reading the file.
      */
     public static ExtensionSettings readSettingsFromYaml(String extensionSettingsPath) throws IOException {
+        Yaml yaml = new Yaml(new SafeConstructor());
         URL resource = Extension.class.getResource(extensionSettingsPath);
         if (resource == null) {
-            return null;
+            throw new IOException("extension.yml does not exist at path [" + extensionSettingsPath + "]");
         }
-        File file = new File(resource.getPath());
-        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-        return objectMapper.readValue(file, ExtensionSettings.class);
+        try (InputStream inputStream = Files.newInputStream(Path.of(resource.toURI()))) {
+            Map<String, Object> extensionMap = yaml.load(inputStream);
+            inputStream.close();
+            if (extensionMap == null) {
+                throw new IOException("extension.yml is empty");
+            }
+            return new ExtensionSettings(
+                extensionMap.get("extensionName").toString(),
+                extensionMap.get("hostAddress").toString(),
+                extensionMap.get("hostPort").toString(),
+                extensionMap.get("opensearchAddress").toString(),
+                extensionMap.get("opensearchPort").toString()
+            );
+        } catch (URISyntaxException e) {
+            throw new IOException("Error reading from extension.yml");
+        }
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
@@ -9,27 +9,21 @@
 
 package org.opensearch.sdk;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.io.File;
 import java.io.IOException;
 
 public class TestExtensionSettings extends OpenSearchTestCase {
     private static final String EXTENSION_DESCRIPTOR_CLASSPATH = "/extension.yml";
-    private static final String EXTENSION_DESCRIPTOR_FILEPATH = "src/test/resources" + EXTENSION_DESCRIPTOR_CLASSPATH;
     private ExtensionSettings extensionSettings;
 
     @Override
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        File file = new File(EXTENSION_DESCRIPTOR_FILEPATH);
-        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
-        extensionSettings = objectMapper.readValue(file, ExtensionSettings.class);
+        extensionSettings = ExtensionSettings.readSettingsFromYaml(EXTENSION_DESCRIPTOR_CLASSPATH);
     }
 
     @Test
@@ -60,7 +54,7 @@ public class TestExtensionSettings extends OpenSearchTestCase {
         assertEquals(extensionSettings.getHostPort(), settings.getHostPort());
         assertEquals(extensionSettings.getOpensearchAddress(), settings.getOpensearchAddress());
         assertEquals(extensionSettings.getOpensearchPort(), settings.getOpensearchPort());
-        assertNull(ExtensionSettings.readSettingsFromYaml("this/path/does/not/exist"));
-        assertNull(ExtensionSettings.readSettingsFromYaml(EXTENSION_DESCRIPTOR_CLASSPATH + "filedoesnotexist"));
+        expectThrows(IOException.class, () -> ExtensionSettings.readSettingsFromYaml("this/path/does/not/exist"));
+        expectThrows(IOException.class, () -> ExtensionSettings.readSettingsFromYaml(EXTENSION_DESCRIPTOR_CLASSPATH + "filedoesnotexist"));
     }
 }


### PR DESCRIPTION
### Description
YAML reading for extension.yml used to utilize the jackson-databind library.  As part of an initiative to remove jackson-databind, this process was replaced with similar logic using the snakeyaml library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
