### PR TITLE
Baseline MAINTAINERS and CODEOWNERS with active maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @CEHENKLE @joshpalis @owaiskazi19 @ryanbogan @saratvemulapalli @dbwiddis
+*   @joshpalis @owaiskazi19 @ryanbogan @saratvemulapalli @dbwiddis

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 build-idea/
 out/
 
+# eclipse files
+.classpath
+.project
+
 # gradle stuff
 .gradle/
 build/

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,9 +6,14 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer        | GitHub ID                                               | Affiliation |
 | ----------------- | ------------------------------------------------------- | ----------- |
-| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
 | Josh Palis        | [joshpalis](https://github.com/joshpalis)               | Amazon      |
 | Owais Kazi        | [owaiskazi19](https://github.com/owaiskazi19)           | Amazon      |
 | Ryan Bogan        | [ryanbogan](https://github.com/ryanbogan)               | Amazon      |
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 | Dan Widdis        | [dbwiddis](https://github.com/dbwiddis)                 | Amazon      |
+
+## Emeritus Maintainers
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
+| Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |


### PR DESCRIPTION
### Description

Updates MAINTAINERS and CODEOWNERS with non-active maintainers moved to emeritus.

### Issues Resolved

Fixes #448 (and its doppelgänger #449)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
