### PR TITLE
Removed lucene dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     def opensearchVersion = "3.0.0-SNAPSHOT"
     def log4jVersion = "2.19.0"
     def nettyVersion = "4.1.89.Final"
-    def luceneVersion = "9.4.2"
     def jacksonDatabindVersion = "2.14.2"
     def guavaVersion = "31.1-jre"
     def guiceVersion = "5.1.0"
@@ -96,7 +95,6 @@ dependencies {
     implementation("org.opensearch.client:opensearch-java:${opensearchVersion}")
     implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation("io.netty:netty-all:${nettyVersion}")
-    implementation("org.apache.lucene:lucene-core:${luceneVersion}")
     testCompileOnly("junit:junit:${junit4Version}") {
         exclude module : 'hamcrest'
         exclude module : 'hamcrest-core'


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-sdk-java/pull/388. As SDK does not have dependency on lucene, removing it will be of less work for the mend bot :)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
