### PR TITLE
Implement Action dependency injection

### DIFF
--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -34,11 +34,9 @@ The [Java Client for OpenSearch](https://github.com/opensearch-project/opensearc
 The `SDKRestClient` provides wrapper methods matching the `Client` API (but not implementing it), implemented internally with the (soon to be deprecated) `RestHighLevelClient`.  While this speeds migration efforts, it should be considered a temporary "bridge" with follow up migration efforts to the `OpenSearchClient` planned.
  - While the class names and method parameters are the same, the `Request` and `Response` classes are often in different packages. In most cases, other than changing `import` statements, no additional code changes are required. In a few cases, there are minor changes required to interface with the new response class API.
 
-The `client.execute(action, request, responseListener)` method is not yet implemented. Instead:
- - Instantiate an instance of the corresponding transport action
- - Pass the `request` and `responseListener` to the action's `doExecute()` method.
+The `client.execute(action, request, responseListener)` method is implemented on the SDKClient.
 
-Remove the transport action inheritance from HandledTransportAction. This may change to direct inheritance of `TransportAction` and implementation of `execute()`.
+Change the transport action inheritance from HandledTransportAction to directly inherit from `TransportAction`.
 
 ### Replace RestHandler with ExtensionRestHandler
 

--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -12,11 +12,7 @@ package org.opensearch.sdk;
 import java.util.Collections;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
-import org.opensearch.action.ActionRequest;
-import org.opensearch.action.ActionResponse;
-import org.opensearch.action.support.TransportAction;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.threadpool.ExecutorBuilder;
@@ -61,17 +57,6 @@ public interface Extension {
      */
     default Collection<Object> createComponents() {
         return Collections.emptyList();
-    }
-
-    /**
-     * Gets an optional list of custom {@link TransportAction} for the extension to register with OpenSearch.
-     * <p>
-     * TODO: ActionExtension#getActions will replace this: https://github.com/opensearch-project/opensearch-sdk-java/issues/368
-     *
-     * @return a list of custom transport actions this extension uses.
-     */
-    default Map<String, Class<? extends TransportAction<? extends ActionRequest, ? extends ActionResponse>>> getActionsMap() {
-        return Collections.emptyMap();
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -158,7 +158,7 @@ public class ExtensionsRunner {
             b.bind(NamedXContentRegistry.class).toInstance(getNamedXContentRegistry().getRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
 
-            b.bind(SDKClient.class).toInstance(new SDKClient());
+            b.bind(SDKClient.class);
             b.bind(SDKClusterService.class).toInstance(new SDKClusterService(this));
         });
         // Bind the return values from create components
@@ -178,7 +178,7 @@ public class ExtensionsRunner {
             this.transportActions = new TransportActions(Collections.emptyMap());
         }
 
-        Guice.createInjector((com.google.inject.Module[]) modules.toArray());
+        Guice.createInjector(modules);
 
         if (extension instanceof ActionExtension) {
             // store REST handlers in the registry

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -39,6 +39,7 @@ import org.opensearch.sdk.handlers.ExtensionsIndicesModuleRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
 import org.opensearch.sdk.handlers.UpdateSettingsRequestHandler;
+import org.opensearch.tasks.TaskManager;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
@@ -110,6 +111,10 @@ public class ExtensionsRunner {
      * A thread pool for the extension.
      */
     private final ThreadPool threadPool;
+    /**
+     * A task manager for the extension
+     */
+    private final TaskManager taskManager;
 
     private ExtensionNamedXContentRegistry extensionNamedXContentRegistry = new ExtensionNamedXContentRegistry(
         Settings.EMPTY,
@@ -146,6 +151,7 @@ public class ExtensionsRunner {
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
             .build();
         this.threadPool = new ThreadPool(settings);
+        this.taskManager = new TaskManager(settings, threadPool, Collections.emptySet());
 
         List<com.google.inject.Module> modules = new ArrayList<>();
         // Base bindings
@@ -157,6 +163,7 @@ public class ExtensionsRunner {
             // https://github.com/opensearch-project/opensearch-sdk-java/issues/447
             b.bind(NamedXContentRegistry.class).toInstance(getNamedXContentRegistry().getRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
+            b.bind(TaskManager.class).toInstance(taskManager);
 
             b.bind(SDKClient.class);
             b.bind(SDKClusterService.class).toInstance(new SDKClusterService(this));

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -82,20 +82,13 @@ public class SDKClient implements Closeable {
 
     // Used by client.execute
     @SuppressWarnings("rawtypes")
+    @Inject
     private Map<ActionType, TransportAction> actions;
 
     /**
      * Instantiate this client.
-     * <p>
-     * This is injected via Guice.
-     *
-     * @param actions A map of ActionType to TransportAction
      */
-    @SuppressWarnings("rawtypes")
-    @Inject
-    public SDKClient(Map<ActionType, TransportAction> actions) {
-        this.actions = actions;
-    }
+    public SDKClient() {}
 
     /**
      * Create and configure a RestClientBuilder

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -94,7 +94,7 @@ public class SDKClient implements Closeable {
      * Create and configure a RestClientBuilder
      *
      * @param hostAddress The address the client should connect to
-     * @param port        The port the client should connect to
+     * @param port The port the client should connect to
      * @return An instance of the builder
      */
     private static RestClientBuilder builder(String hostAddress, int port) {
@@ -142,7 +142,7 @@ public class SDKClient implements Closeable {
      * Initializes an OpenSearchClient using OpenSearch JavaClient
      *
      * @param hostAddress The address of OpenSearch cluster, client can connect to
-     * @param port        The port of OpenSearch cluster
+     * @param port The port of OpenSearch cluster
      * @return The SDKClient implementation of OpenSearchClient. The user is responsible for calling
      *         {@link #doCloseJavaClient()} when finished with the client
      */
@@ -234,11 +234,11 @@ public class SDKClient implements Closeable {
     /**
      * Executes a Transport Action
      *
-     * @param <Request>  The Request type for the action
+     * @param <Request> The Request type for the action
      * @param <Response> The Response type for the action
-     * @param action     The registered action
-     * @param request    The Request
-     * @param listener   An action listener for the Response
+     * @param action The registered action
+     * @param request The Request
+     * @param listener An action listener for the Response
      */
     public final <Request extends ActionRequest, Response extends ActionResponse> void execute(
         ActionType<Response> action,
@@ -254,12 +254,9 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Wraps an internal {@link RestHighLevelClient} using method signatures expected by {@link Client} and
-     * {@link org.opensearch.client.AdminClient} syntax, providing a drop-in replacement in existing plugins with a
-     * minimum of code changes.
+     * Wraps an internal {@link RestHighLevelClient} using method signatures expected by {@link Client} and {@link org.opensearch.client.AdminClient} syntax, providing a drop-in replacement in existing plugins with a minimum of code changes.
      * <p>
-     * While some {@link Client} interface methods are implemented here, the interface is intentionally not fully
-     * implemented as it is intended to be deprecated.
+     * While some {@link Client} interface methods are implemented here, the interface is intentionally not fully implemented as it is intended to be deprecated.
      * <p>
      * Do not use this client for new development.
      *
@@ -328,7 +325,7 @@ public class SDKClient implements Closeable {
         /**
          * Gets all the documents that match the criteria
          *
-         * @param request  The multiGet Request
+         * @param request The multiGet Request
          * @param listener A listener to be notified with a result
          */
         public void multiGet(MultiGetRequest request, ActionListener<MultiGetResponse> listener) {
@@ -338,7 +335,7 @@ public class SDKClient implements Closeable {
         /**
          * Deletes a document from the index based on the index, and id.
          *
-         * @param request  The delete request
+         * @param request The delete request
          * @param listener A listener to be notified with a result
          * @see Requests#deleteRequest(String)
          */
@@ -349,7 +346,7 @@ public class SDKClient implements Closeable {
         /**
          * Search across one or more indices with a query.
          *
-         * @param request  The search request
+         * @param request The search request
          * @param listener A listener to be notified of the result
          * @see Requests#searchRequest(String...)
          */
@@ -364,8 +361,7 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Wraps an internal {@link ClusterAdminClient}, providing a drop-in replacement in existing plugins with a minimum
-     * of code changes.
+     * Wraps an internal {@link ClusterAdminClient}, providing a drop-in replacement in existing plugins with a minimum of code changes.
      * <p>
      * Do not use this client for new development.
      */
@@ -388,8 +384,7 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Wraps an internal {@link IndicesClient}, providing a drop-in replacement in existing plugins with a minimum of
-     * code changes.
+     * Wraps an internal {@link IndicesClient}, providing a drop-in replacement in existing plugins with a minimum of code changes.
      * <p>
      * Do not use this client for new development.
      */
@@ -410,7 +405,7 @@ public class SDKClient implements Closeable {
          * Asynchronously creates an index using the Create Index API.
          *
          * @param createIndexRequest the request
-         * @param listener           the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable create(CreateIndexRequest createIndexRequest, ActionListener<CreateIndexResponse> listener) {
@@ -421,7 +416,7 @@ public class SDKClient implements Closeable {
          * Asynchronously deletes an index using the Delete Index API.
          *
          * @param deleteIndexRequest the request
-         * @param listener           the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable delete(DeleteIndexRequest deleteIndexRequest, ActionListener<AcknowledgedResponse> listener) {
@@ -432,7 +427,7 @@ public class SDKClient implements Closeable {
          * Asynchronously updates the mappings on an index using the Put Mapping API.
          *
          * @param putMappingRequest the request
-         * @param listener          the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable putMapping(PutMappingRequest putMappingRequest, ActionListener<AcknowledgedResponse> listener) {
@@ -443,7 +438,7 @@ public class SDKClient implements Closeable {
          * Asynchronously retrieves the mappings on an index on indices using the Get Mapping API.
          *
          * @param getMappingsRequest the request
-         * @param listener           the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable getMapping(GetMappingsRequest getMappingsRequest, ActionListener<GetMappingsResponse> listener) {
@@ -454,7 +449,7 @@ public class SDKClient implements Closeable {
          * Asynchronously rolls over an index using the Rollover Index API.
          *
          * @param rolloverRequest the request
-         * @param listener        the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable rolloverIndex(RolloverRequest rolloverRequest, ActionListener<RolloverResponse> listener) {
@@ -465,7 +460,7 @@ public class SDKClient implements Closeable {
          * Asynchronously gets one or more aliases using the Get Index Aliases API.
          *
          * @param getAliasesRequest the request
-         * @param listener          the listener to be notified upon request completion
+         * @param listener the listener to be notified upon request completion
          * @return cancellable that may be used to cancel the request
          */
         public Cancellable getAliases(GetAliasesRequest getAliasesRequest, ActionListener<GetAliasesResponse> listener) {

--- a/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
+++ b/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.action;
+
+import java.util.Map;
+
+import org.opensearch.common.NamedRegistry;
+import org.opensearch.sdk.ActionExtension.ActionHandler;
+import org.opensearch.sdk.ActionExtension;
+
+import static java.util.Collections.unmodifiableMap;
+
+public class SDKActionModule {
+
+    private final Map<String, ActionHandler<?, ?>> actions;
+
+    public SDKActionModule(ActionExtension extension) {
+        this.actions = setupActions(extension);
+    }
+
+    public Map<String, ActionHandler<?, ?>> getActions() {
+        return actions;
+    }
+
+    private static Map<String, ActionHandler<?, ?>> setupActions(ActionExtension extension) {
+        // Subclass NamedRegistry for easy registration
+        class ActionRegistry extends NamedRegistry<ActionHandler<?, ?>> {
+            ActionRegistry() {
+                super("action");
+            }
+
+            public void register(ActionHandler<?, ?> handler) {
+                register(handler.getAction().name(), handler);
+            }
+        }
+        ActionRegistry actions = new ActionRegistry();
+        // Register getActions in it
+        extension.getActions().stream().forEach(actions::register);
+
+        return unmodifiableMap(actions.getRegistry());
+    }
+
+}

--- a/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
+++ b/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
@@ -10,7 +10,9 @@
 package org.opensearch.sdk.action;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.opensearch.action.support.ActionFilters;
 import org.opensearch.common.NamedRegistry;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.ActionExtension;
@@ -20,13 +22,20 @@ import static java.util.Collections.unmodifiableMap;
 public class SDKActionModule {
 
     private final Map<String, ActionHandler<?, ?>> actions;
+    private final ActionFilters actionFilters;
 
     public SDKActionModule(ActionExtension extension) {
         this.actions = setupActions(extension);
+        this.actionFilters = setupActionFilters(extension);
+        // TODO: consider moving Rest Handler registration here
     }
 
     public Map<String, ActionHandler<?, ?>> getActions() {
         return actions;
+    }
+
+    public ActionFilters getActionFilters() {
+        return actionFilters;
     }
 
     private static Map<String, ActionHandler<?, ?>> setupActions(ActionExtension extension) {
@@ -45,6 +54,10 @@ public class SDKActionModule {
         extension.getActions().stream().forEach(actions::register);
 
         return unmodifiableMap(actions.getRegistry());
+    }
+
+    private static ActionFilters setupActionFilters(ActionExtension extension) {
+        return new ActionFilters(extension.getActionFilters().stream().collect(Collectors.toSet()));
     }
 
 }

--- a/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
+++ b/src/main/java/org/opensearch/sdk/action/SDKActionModule.java
@@ -25,11 +25,19 @@ import org.opensearch.sdk.ActionExtension;
 
 import static java.util.Collections.unmodifiableMap;
 
+/**
+ * A module for injecting getActions classes into Guice.
+ */
 public class SDKActionModule extends AbstractModule {
 
     private final Map<String, ActionHandler<?, ?>> actions;
     private final ActionFilters actionFilters;
 
+    /**
+     * Instantiate this module
+     *
+     * @param extension An instance of {@link ActionExtension}.
+     */
     public SDKActionModule(ActionExtension extension) {
         this.actions = setupActions(extension);
         this.actionFilters = setupActionFilters(extension);

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -10,14 +10,20 @@
 package org.opensearch.sdk.sample.helloworld;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionResponse;
 import org.opensearch.sdk.BaseExtension;
 import org.opensearch.sdk.Extension;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.sdk.ExtensionSettings;
 import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.sample.helloworld.rest.RestHelloAction;
+import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
+import org.opensearch.sdk.sample.helloworld.transport.SampleTransportAction;
 
 /**
  * Sample class to demonstrate how to use the OpenSearch SDK for Java to create
@@ -49,6 +55,11 @@ public class HelloWorldExtension extends BaseExtension {
     @Override
     public List<ExtensionRestHandler> getExtensionRestHandlers() {
         return List.of(new RestHelloAction());
+    }
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Arrays.asList(new ActionHandler<>(SampleAction.INSTANCE, SampleTransportAction.class));
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld.transport;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * A sample {@link ActionType} used as they key for the action map
+ */
+public class SampleAction extends ActionType<SampleResponse> {
+
+    /**
+     * The name to look up this action with
+     */
+    public static final String NAME = "helloworld/sample";
+    /**
+     * The singleton instance of this class
+     */
+    public static final SampleAction INSTANCE = new SampleAction();
+
+    private SampleAction() {
+        super(NAME, SampleResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleRequest.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld.transport;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+/**
+ * A sample request class to demonstrate extension actions
+ */
+public class SampleRequest extends ActionRequest {
+
+    private final String name;
+
+    /**
+     * Instantiate this request
+     *
+     * @param name A name to pass to the action
+     */
+    public SampleRequest(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Instantiate this request from a byte stream
+     *
+     * @param in the byte stream
+     * @throws IOException on failure reading the stream
+     */
+    public SampleRequest(StreamInput in) throws IOException {
+        this.name = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleResponse.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld.transport;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+
+/**
+ * A sample response class to demonstrate extension actions
+ */
+public class SampleResponse extends ActionResponse {
+
+    private final String greeting;
+
+    /**
+     * Instantiate this response
+     *
+     * @param greeting The greeting to return
+     */
+    public SampleResponse(String greeting) {
+        this.greeting = greeting;
+    }
+
+    /**
+     * Instantiate this response from a byte stream
+     *
+     * @param in the byte stream
+     * @throws IOException on failure reading the stream
+     */
+    public SampleResponse(StreamInput in) throws IOException {
+        this.greeting = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(greeting);
+    }
+
+    public String getGreeting() {
+        return greeting;
+    }
+}

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleTransportAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleTransportAction.java
@@ -15,6 +15,8 @@ import org.opensearch.action.support.TransportAction;
 import org.opensearch.tasks.Task;
 import org.opensearch.tasks.TaskManager;
 
+import com.google.inject.Inject;
+
 /**
  * A sample {@link TransportAction} used as they value for the action map
  */
@@ -27,6 +29,7 @@ public class SampleTransportAction extends TransportAction<SampleRequest, Sample
      * @param actionFilters Action filters
      * @param taskManager The task manager
      */
+    @Inject
     protected SampleTransportAction(String actionName, ActionFilters actionFilters, TaskManager taskManager) {
         super(actionName, actionFilters, taskManager);
     }

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleTransportAction.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/transport/SampleTransportAction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld.transport;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.TransportAction;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskManager;
+
+/**
+ * A sample {@link TransportAction} used as they value for the action map
+ */
+public class SampleTransportAction extends TransportAction<SampleRequest, SampleResponse> {
+
+    /**
+     * Instantiate this action
+     *
+     * @param actionName The action name
+     * @param actionFilters Action filters
+     * @param taskManager The task manager
+     */
+    protected SampleTransportAction(String actionName, ActionFilters actionFilters, TaskManager taskManager) {
+        super(actionName, actionFilters, taskManager);
+    }
+
+    @Override
+    protected void doExecute(Task task, SampleRequest request, ActionListener<SampleResponse> listener) {
+        // Fail if name is empty
+        if (request.getName().isBlank()) {
+            listener.onFailure(new IllegalArgumentException("The request name is blank."));
+        } else {
+            listener.onResponse(new SampleResponse("Hello, " + request.getName()));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -34,6 +34,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -46,7 +48,7 @@ public class TestSDKClient extends OpenSearchTestCase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        this.sdkClient = new SDKClient();
+        this.sdkClient = new SDKClient(Collections.emptyMap());
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -34,8 +34,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-import java.util.Collections;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -48,7 +46,7 @@ public class TestSDKClient extends OpenSearchTestCase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        this.sdkClient = new SDKClient(Collections.emptyMap());
+        this.sdkClient = new SDKClient();
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/transport/TestSampleAction.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/transport/TestSampleAction.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.sample.helloworld.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamInput;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TestSampleAction extends OpenSearchTestCase {
+
+    @Test
+    public void testSampleAction() {
+        SampleAction action = SampleAction.INSTANCE;
+        assertEquals(SampleAction.NAME, action.name());
+    }
+
+    @Test
+    public void testSampleRequest() throws IOException {
+        String name = "test";
+        SampleRequest request = new SampleRequest(name);
+        assertEquals(name, request.getName());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            request.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                request = new SampleRequest(in);
+                assertEquals(name, request.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testSampleResponse() throws IOException {
+        String greeting = "test";
+        SampleResponse response = new SampleResponse(greeting);
+        assertEquals(greeting, response.getGreeting());
+
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            response.writeTo(out);
+            out.flush();
+            try (BytesStreamInput in = new BytesStreamInput(BytesReference.toBytes(out.bytes()))) {
+                response = new SampleResponse(in);
+                assertEquals(greeting, response.getGreeting());
+            }
+        }
+    }
+
+    @Test
+    public void testSampleTransportAction() throws Exception {
+        String expectedName = "world";
+        String expectedGreeting = "Hello, " + expectedName;
+
+        SampleRequest request = new SampleRequest(expectedName);
+        CompletableFuture<SampleResponse> responseFuture = new CompletableFuture<>();
+        ActionListener<SampleResponse> listener = new ActionListener<SampleResponse>() {
+
+            @Override
+            public void onResponse(SampleResponse response) {
+                responseFuture.complete(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                responseFuture.completeExceptionally(e);
+            }
+        };
+
+        // test successful response
+        SampleTransportAction action = new SampleTransportAction(null, new ActionFilters(Collections.emptySet()), null);
+        action.doExecute(null, request, listener);
+        SampleResponse response = responseFuture.get(1, TimeUnit.SECONDS);
+        assertEquals(expectedGreeting, response.getGreeting());
+    }
+
+    @Test
+    public void testExceptionalSampleTransportAction() throws Exception {
+        String expectedName = "";
+
+        SampleRequest request = new SampleRequest(expectedName);
+        CompletableFuture<SampleResponse> responseFuture = new CompletableFuture<>();
+        ActionListener<SampleResponse> listener = new ActionListener<SampleResponse>() {
+
+            @Override
+            public void onResponse(SampleResponse response) {
+                responseFuture.complete(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                responseFuture.completeExceptionally(e);
+            }
+        };
+
+        SampleTransportAction action = new SampleTransportAction(null, new ActionFilters(Collections.emptySet()), null);
+        action.doExecute(null, request, listener);
+        ExecutionException ex = assertThrows(ExecutionException.class, () -> responseFuture.get(1, TimeUnit.SECONDS));
+        Throwable cause = ex.getCause();
+        assertTrue(cause instanceof IllegalArgumentException);
+        assertEquals("The request name is blank.", cause.getMessage());
+    }
+}


### PR DESCRIPTION
### Description

Fully implements `getActions()` extension point
 - Injects the actions in Guice module
 - Enables migration of `client.execute(action, request, listener)` syntax via SDKClient
 - Populates the `TransportActions` object on the extensions runner using the expected map types
 - Adds tests

### Issues Resolved

Fixes #368 
Fixes #283 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
