### PR TITLE
Create SDKNamedXContentRegistry class and provide updated registry

### DIFF
--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -42,12 +42,20 @@ Change the transport action inheritance from HandledTransportAction to directly 
 
 Pass the `ExtensionsRunner` and `Extension` objects to the handler and access `createComponent` equivalents, such as:
 ```java
-this.namedXContentRegistry = extensionsRunner.getNamedXContentRegistry().getRegistry();
+this.sdkNamedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
+```
+
+When a `NamedXContentRegistry` object is required, get the current one from `this.sdkNamedXContentRegistry.getRegistry()`.
+
+Other potential initialization values:
+```java
 this.environmentSettings = extensionsRunner.getEnvironmentSettings();
 this.transportService = extensionsRunner.getExtensionTransportService();
 this.restClient = anomalyDetectorExtension.getRestClient();
 this.sdkClusterService = new SDKClusterService(extensionsRunner);
 ```
+
+Many of these components are also available via Guice injection.
 
 Optionally change the `routes()` to `routeHandlers()`.  Change `prepareRequest()` to `handleRequest()`.
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -119,10 +119,7 @@ public class ExtensionsRunner {
      */
     private final TaskManager taskManager;
 
-    private ExtensionNamedXContentRegistry extensionNamedXContentRegistry = new ExtensionNamedXContentRegistry(
-        Settings.EMPTY,
-        Collections.emptyList()
-    );
+    private SDKNamedXContentRegistry extensionNamedXContentRegistry = new SDKNamedXContentRegistry(Settings.EMPTY, Collections.emptyList());
     private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler(this);
     private ExtensionsIndicesModuleRequestHandler extensionsIndicesModuleRequestHandler = new ExtensionsIndicesModuleRequestHandler();
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
@@ -270,7 +267,7 @@ public class ExtensionsRunner {
      *
      * @param registry assign value for namedXContentRegistry
      */
-    public void setNamedXContentRegistry(ExtensionNamedXContentRegistry registry) {
+    public void setNamedXContentRegistry(SDKNamedXContentRegistry registry) {
         this.extensionNamedXContentRegistry = registry;
     }
 
@@ -279,7 +276,7 @@ public class ExtensionsRunner {
      *
      * @return the NamedXContentRegistry if initialized, an empty registry otherwise.
      */
-    public ExtensionNamedXContentRegistry getNamedXContentRegistry() {
+    public SDKNamedXContentRegistry getNamedXContentRegistry() {
         return this.extensionNamedXContentRegistry;
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -172,9 +172,7 @@ public class ExtensionsRunner {
             b.bind(ExtensionsRunner.class).toInstance(this);
             b.bind(Extension.class).toInstance(extension);
 
-            // FIXME: Change this to a provider interface
-            // https://github.com/opensearch-project/opensearch-sdk-java/issues/447
-            b.bind(NamedXContentRegistry.class).toInstance(getNamedXContentRegistry().getRegistry());
+            b.bind(SDKNamedXContentRegistry.class).toInstance(getNamedXContentRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
             b.bind(TaskManager.class).toInstance(taskManager);
 

--- a/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
+++ b/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
@@ -26,7 +26,7 @@ import org.opensearch.search.SearchModule;
 /**
  * Combines Extension NamedXContent with core OpenSearch NamedXContent
  */
-public class ExtensionNamedXContentRegistry {
+public class SDKNamedXContentRegistry {
     private final NamedXContentRegistry namedXContentRegistry;
 
     /**
@@ -36,7 +36,7 @@ public class ExtensionNamedXContentRegistry {
      * @param settings OpenSearch environment settings
      * @param extensionNamedXContent List of NamedXContentRegistry.Entry to be registered
      */
-    public ExtensionNamedXContentRegistry(Settings settings, List<NamedXContentRegistry.Entry> extensionNamedXContent) {
+    public SDKNamedXContentRegistry(Settings settings, List<NamedXContentRegistry.Entry> extensionNamedXContent) {
         this.namedXContentRegistry = new NamedXContentRegistry(
             Stream.of(
                 extensionNamedXContent.stream(),

--- a/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
+++ b/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
@@ -20,6 +20,7 @@ import org.opensearch.cluster.ClusterModule;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.NamedXContentRegistry.Entry;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.search.SearchModule;
 
@@ -37,7 +38,11 @@ public class SDKNamedXContentRegistry {
      * @param extensionNamedXContent List of NamedXContentRegistry.Entry to be registered
      */
     public SDKNamedXContentRegistry(Settings settings, List<NamedXContentRegistry.Entry> extensionNamedXContent) {
-        this.namedXContentRegistry = new NamedXContentRegistry(
+        this.namedXContentRegistry = createRegistry(settings, extensionNamedXContent);
+    }
+
+    private NamedXContentRegistry createRegistry(Settings settings, List<Entry> extensionNamedXContent) {
+        return new NamedXContentRegistry(
             Stream.of(
                 extensionNamedXContent.stream(),
                 NetworkModule.getNamedXContents().stream(),

--- a/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
+++ b/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
@@ -28,23 +28,33 @@ import org.opensearch.search.SearchModule;
  * Combines Extension NamedXContent with core OpenSearch NamedXContent
  */
 public class SDKNamedXContentRegistry {
-    private final NamedXContentRegistry namedXContentRegistry;
+    private NamedXContentRegistry namedXContentRegistry;
 
     /**
-     * Creates and populates a NamedXContentRegistry with the given NamedXContentRegistry entries for this extension and
-     * locally defined content.
+     * Creates and populates a NamedXContentRegistry with the NamedXContentRegistry entries for this extension and locally defined content.
      *
-     * @param settings OpenSearch environment settings
-     * @param extensionNamedXContent List of NamedXContentRegistry.Entry to be registered
+     * @param runner The ExtensionsRunner instance.
      */
-    public SDKNamedXContentRegistry(Settings settings, List<NamedXContentRegistry.Entry> extensionNamedXContent) {
-        this.namedXContentRegistry = createRegistry(settings, extensionNamedXContent);
+    public SDKNamedXContentRegistry(ExtensionsRunner runner) {
+        this.namedXContentRegistry = createRegistry(runner.getEnvironmentSettings(), runner.getCustomNamedXContent());
+    }
+
+    /**
+     * Updates the NamedXContentRegistry with the NamedXContentRegistry entries for this extension and locally defined content.
+     * <p>
+     * Only necessary if environment settings have changed.
+     *
+     * @param runner The ExtensionsRunner instance.
+     */
+    public void updateNamedXContentRegistry(ExtensionsRunner runner) {
+        this.namedXContentRegistry = createRegistry(runner.getEnvironmentSettings(), runner.getCustomNamedXContent());
     }
 
     private NamedXContentRegistry createRegistry(Settings settings, List<Entry> extensionNamedXContent) {
+        Stream<Entry> extensionContent = extensionNamedXContent == null ? Stream.empty() : extensionNamedXContent.stream();
         return new NamedXContentRegistry(
             Stream.of(
-                extensionNamedXContent.stream(),
+                extensionContent,
                 NetworkModule.getNamedXContents().stream(),
                 IndicesModule.getNamedXContents().stream(),
                 new SearchModule(settings, Collections.emptyList()).getNamedXContents().stream(),

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.InitializeExtensionRequest;
 import org.opensearch.discovery.InitializeExtensionResponse;
-import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.transport.TransportService;
 
@@ -68,7 +67,7 @@ public class ExtensionsInitRequestHandler {
             // Get OpenSearch Settings and set values on ExtensionsRunner
             Settings settings = extensionsRunner.sendEnvironmentSettingsRequest(extensionTransportService);
             extensionsRunner.setEnvironmentSettings(settings);
-            extensionsRunner.setNamedXContentRegistry(new SDKNamedXContentRegistry(settings, extensionsRunner.getCustomNamedXContent()));
+            extensionsRunner.updateNamedXContentRegistry();
 
             // Last step of initialization
             extensionsRunner.setInitialized();

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.discovery.InitializeExtensionRequest;
 import org.opensearch.discovery.InitializeExtensionResponse;
-import org.opensearch.sdk.ExtensionNamedXContentRegistry;
+import org.opensearch.sdk.SDKNamedXContentRegistry;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.transport.TransportService;
 
@@ -68,9 +68,7 @@ public class ExtensionsInitRequestHandler {
             // Get OpenSearch Settings and set values on ExtensionsRunner
             Settings settings = extensionsRunner.sendEnvironmentSettingsRequest(extensionTransportService);
             extensionsRunner.setEnvironmentSettings(settings);
-            extensionsRunner.setNamedXContentRegistry(
-                new ExtensionNamedXContentRegistry(settings, extensionsRunner.getCustomNamedXContent())
-            );
+            extensionsRunner.setNamedXContentRegistry(new SDKNamedXContentRegistry(settings, extensionsRunner.getCustomNamedXContent()));
 
             // Last step of initialization
             extensionsRunner.setInitialized();

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -220,8 +220,8 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
 
         assertTrue(extensionsRunner.getCustomNamedXContent().isEmpty());
         assertTrue(extensionsRunner.getNamedXContentRegistry().getRegistry() instanceof NamedXContentRegistry);
-        extensionsRunner.setNamedXContentRegistry(null);
-        assertNull(extensionsRunner.getNamedXContentRegistry());
+        extensionsRunner.updateNamedXContentRegistry();
+        assertTrue(extensionsRunner.getNamedXContentRegistry().getRegistry() instanceof NamedXContentRegistry);
         assertTrue(extensionsRunner.getExtension() instanceof BaseExtension);
         assertEquals(extensionsRunner, ((BaseExtension) extensionsRunner.getExtension()).extensionsRunner());
         assertTrue(extensionsRunner.getThreadPool() instanceof ThreadPool);

--- a/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
@@ -95,24 +95,13 @@ public class TestSDKNamedXContentRegistry extends OpenSearchTestCase {
         }
     }
 
-    private static class ExampleRunnerForTest extends ExtensionsRunner {
+    private static class ExampleRunnerForTest extends ExtensionsRunnerForTest {
 
         private List<Entry> testNamedXContent = Collections.emptyList();
         private final SDKNamedXContentRegistry sdkNamedXContentRegistry = new SDKNamedXContentRegistry(this);
 
         public ExampleRunnerForTest() throws IOException {
-            super(
-                new BaseExtension(
-                    new ExtensionSettings(
-                        ExtensionsRunnerForTest.NODE_NAME,
-                        ExtensionsRunnerForTest.NODE_HOST,
-                        ExtensionsRunnerForTest.NODE_PORT,
-                        "127.0.0.1",
-                        "9200"
-                    )
-                ) {
-                }
-            );
+            super();
         }
 
         @Override

--- a/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
@@ -34,8 +34,8 @@ import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class TestExtensionNamedXContentRegistry extends OpenSearchTestCase {
-    private ExtensionNamedXContentRegistry extensionNamedXContentRegistry;
+public class TestSDKNamedXContentRegistry extends OpenSearchTestCase {
+    private SDKNamedXContentRegistry extensionNamedXContentRegistry;
 
     private static class Example implements ToXContentObject {
         public static final String NAME = "Example";
@@ -101,7 +101,7 @@ public class TestExtensionNamedXContentRegistry extends OpenSearchTestCase {
     @BeforeEach
     public void setUp() {
         List<NamedXContentRegistry.Entry> namedXContents = Collections.singletonList(Example.XCONTENT_REGISTRY);
-        this.extensionNamedXContentRegistry = new ExtensionNamedXContentRegistry(Settings.EMPTY, namedXContents);
+        this.extensionNamedXContentRegistry = new SDKNamedXContentRegistry(Settings.EMPTY, namedXContents);
     }
 
     @Test
@@ -123,24 +123,18 @@ public class TestExtensionNamedXContentRegistry extends OpenSearchTestCase {
     @Test
     public void testNamedXContentRegistryExceptions() {
         // Tests that the registry includes module contents and generates conflicts when adding
+        assertThrows(IllegalArgumentException.class, () -> new SDKNamedXContentRegistry(Settings.EMPTY, NetworkModule.getNamedXContents()));
+        assertThrows(IllegalArgumentException.class, () -> new SDKNamedXContentRegistry(Settings.EMPTY, IndicesModule.getNamedXContents()));
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ExtensionNamedXContentRegistry(Settings.EMPTY, NetworkModule.getNamedXContents())
-        );
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ExtensionNamedXContentRegistry(Settings.EMPTY, IndicesModule.getNamedXContents())
-        );
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new ExtensionNamedXContentRegistry(
+            () -> new SDKNamedXContentRegistry(
                 Settings.EMPTY,
                 new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents()
             )
         );
         assertThrows(
             IllegalArgumentException.class,
-            () -> new ExtensionNamedXContentRegistry(Settings.EMPTY, ClusterModule.getNamedXWriteables())
+            () -> new SDKNamedXContentRegistry(Settings.EMPTY, ClusterModule.getNamedXWriteables())
         );
     }
 }


### PR DESCRIPTION
### Description

1. Renames `ExtensionNamedXContentRegistry` to `SDKNamedXContentRegistry`
2. Uses the `ExtensionsRunner` as an initialization and update parameter
3. Reorders initialization so the initial registry copy in extensions will have the needed content if it's saved
4. Injects the SDK registry rather than the wrapped value so developers have a means to access the updated registry
5. Updates migration guide

### Issues Resolved

Fixes #447 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
