### PR TITLE
Bumping version of main and publishing snapshots after every push

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -2,8 +2,10 @@ name: Publish snapshots to maven
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: 0 */12 * * *
+  push:
+    branches: [
+        main
+    ]
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 1.x
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -3,9 +3,9 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-    branches: [
-        main
-    ]
+    branches:
+      - main
+      - 1.x
 
 jobs:
   build-and-publish-snapshots:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ mainClassName = 'org.opensearch.sdk.sample.helloworld.HelloWorldExtension'
 
 
 group 'org.opensearch.sdk'
-version '1.0.0-SNAPSHOT'
+version '2.0.0-SNAPSHOT'
 
 
 publishing {


### PR DESCRIPTION
### Description
Cron job is currently scheduled for 12 hrs and with changes coming in for SDK repo, snapshot should be published after every push to be available for migration.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/473

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
