### PR TITLE
Pass ExtensionsRunner instance to createComponents

### DIFF
--- a/src/main/java/org/opensearch/sdk/Extension.java
+++ b/src/main/java/org/opensearch/sdk/Extension.java
@@ -53,9 +53,10 @@ public interface Extension {
     /**
      * Returns components added by this extension.
      *
+     * @param runner the ExtensionsRunner instance. Use getters from this object as required to instantiate components to return.
      * @return A collection of objects which will be bound to themselves for dependency injection.
      */
-    default Collection<Object> createComponents() {
+    default Collection<Object> createComponents(ExtensionsRunner runner) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -120,6 +120,9 @@ public class ExtensionsRunner {
     private final TaskManager taskManager;
 
     private final SDKNamedXContentRegistry sdkNamedXContentRegistry;
+    private final SDKClient sdkClient = new SDKClient();
+    private final SDKClusterService sdkClusterService = new SDKClusterService(this);
+
     private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler(this);
     private ExtensionsIndicesModuleRequestHandler extensionsIndicesModuleRequestHandler = new ExtensionsIndicesModuleRequestHandler();
     private ExtensionsIndicesModuleNameRequestHandler extensionsIndicesModuleNameRequestHandler =
@@ -174,10 +177,10 @@ public class ExtensionsRunner {
 
             b.bind(SDKNamedXContentRegistry.class).toInstance(getNamedXContentRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
-            b.bind(TaskManager.class).toInstance(taskManager);
+            b.bind(TaskManager.class).toInstance(getTaskManager());
 
-            b.bind(SDKClient.class);
-            b.bind(SDKClusterService.class).toInstance(new SDKClusterService(this));
+            b.bind(SDKClient.class).toInstance(getSdkClient());
+            b.bind(SDKClusterService.class).toInstance(getSdkClusterService());
         });
         // Bind the return values from create components
         modules.add(this::injectComponents);
@@ -566,6 +569,18 @@ public class ExtensionsRunner {
 
     public ThreadPool getThreadPool() {
         return threadPool;
+    }
+
+    public TaskManager getTaskManager() {
+        return taskManager;
+    }
+
+    public SDKClient getSdkClient() {
+        return sdkClient;
+    }
+
+    public SDKClusterService getSdkClusterService() {
+        return sdkClusterService;
     }
 
     public TransportService getExtensionTransportService() {

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -208,7 +208,7 @@ public class ExtensionsRunner {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void injectComponents(Binder b) {
-        extension.createComponents().stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));
+        extension.createComponents(this).stream().forEach(p -> b.bind((Class) p.getClass()).toInstance(p));
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
@@ -28,7 +28,7 @@ public class TestExtensionInterfaces extends OpenSearchTestCase {
 
         assertTrue(extension.getSettings().isEmpty());
         assertTrue(extension.getNamedXContent().isEmpty());
-        assertTrue(extension.createComponents().isEmpty());
+        assertTrue(extension.createComponents(null).isEmpty());
         assertTrue(extension.getExecutorBuilders(Settings.EMPTY).isEmpty());
     }
 

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -55,6 +55,7 @@ import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
+import org.opensearch.tasks.TaskManager;
 import org.opensearch.sdk.handlers.AcknowledgedResponseHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -225,6 +226,9 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         assertTrue(extensionsRunner.getExtension() instanceof BaseExtension);
         assertEquals(extensionsRunner, ((BaseExtension) extensionsRunner.getExtension()).extensionsRunner());
         assertTrue(extensionsRunner.getThreadPool() instanceof ThreadPool);
+        assertTrue(extensionsRunner.getTaskManager() instanceof TaskManager);
+        assertTrue(extensionsRunner.getSdkClient() instanceof SDKClient);
+        assertTrue(extensionsRunner.getSdkClusterService() instanceof SDKClusterService);
 
         settings = extensionsRunner.getSettings();
         assertEquals(ExtensionsRunnerForTest.NODE_NAME, settings.get(ExtensionsRunner.NODE_NAME_SETTING));


### PR DESCRIPTION
### Description

Guice has not finished initializing the injector when calling `createComponents` as the return objects need to be injected.  Components which require objects from the `ExtensionsRunner` for instantiation need a copy of them available.

While the constructor could be filled with a long list of these parameters (as is done in plugins) this creates a hard API dependency on the parameters, and changing the number of parameters would break compatibility.

By passing the ExtensionsRunner, additional objects can be made available via getters without changing the API.

### Issues Resolved

Improves on #466

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
