### PR TITLE
Added localNode() to SDKCluster service to retrieve the extensionNode from the extensionsRunner

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -303,6 +303,10 @@ public class ExtensionsRunner {
         this.extensionNode = extensionNode;
     }
 
+    public DiscoveryExtensionNode getExtensionNode() {
+        return this.extensionNode;
+    }
+
     public DiscoveryNode getOpensearchNode() {
         return this.opensearchNode;
     }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -303,6 +303,11 @@ public class ExtensionsRunner {
         this.extensionNode = extensionNode;
     }
 
+    /**
+     * Returns the discovery extension node set during extension initialization
+     *
+     * @return the extensionNode
+     */
     public DiscoveryExtensionNode getExtensionNode() {
         return this.extensionNode;
     }

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -14,6 +14,7 @@ import java.util.function.Consumer;
 
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.extensions.DiscoveryExtensionNode;
 
 /**
  * This class simulates methods normally called from OpenSearch ClusterService class.
@@ -40,6 +41,15 @@ public class SDKClusterService {
      */
     public ClusterState state() {
         return extensionsRunner.sendClusterStateRequest(extensionsRunner.getExtensionTransportService());
+    }
+
+    /**
+     *  Returns the local extension node
+     *
+     * @return the local extension node
+     */
+    public DiscoveryExtensionNode localNode() {
+        return extensionsRunner.getExtensionNode();
     }
 
     public SDKClusterSettings getClusterSettings() {

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.extensions.DiscoveryExtensionNode;
 import org.opensearch.sdk.SDKClusterService.SDKClusterSettings;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.TransportService;
@@ -45,6 +46,13 @@ public class TestSDKClusterService extends OpenSearchTestCase {
         ArgumentCaptor<TransportService> argumentCaptor = ArgumentCaptor.forClass(TransportService.class);
         verify(extensionsRunner, times(1)).sendClusterStateRequest(argumentCaptor.capture());
         assertNull(argumentCaptor.getValue());
+    }
+
+    @Test
+    public void testLocalNode() {
+        DiscoveryExtensionNode expectedLocalNode = extensionsRunner.getExtensionNode();
+        DiscoveryExtensionNode localNode = sdkClusterService.localNode();
+        assertEquals(expectedLocalNode, localNode);
     }
 
     @Test


### PR DESCRIPTION
Gives SDKClusterService access to the localNode(), ie the extension node set during extension initialization. This is needed for ADTaskManager

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
