### PR TITLE
Add client.execute to SDKRestClient

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -202,7 +202,7 @@ public class SDKClient implements Closeable {
      */
     @Deprecated
     public SDKRestClient initializeRestClient(String hostAddress, int port) {
-        return new SDKRestClient(new RestHighLevelClient(builder(hostAddress, port)));
+        return new SDKRestClient(this, new RestHighLevelClient(builder(hostAddress, port)));
     }
 
     /**
@@ -234,13 +234,13 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Executes a Transport Action
+     * Executes a generic action, denoted by an {@link ActionType}.
      *
-     * @param <Request> The Request type for the action
-     * @param <Response> The Response type for the action
-     * @param action The registered action
-     * @param request The Request
-     * @param listener An action listener for the Response
+     * @param action The action type to execute.
+     * @param request The action request.
+     * @param listener The listener to receive the response back.
+     * @param <Request> The request type.
+     * @param <Response> The response type.
      */
     public final <Request extends ActionRequest, Response extends ActionResponse> void execute(
         ActionType<Response> action,
@@ -268,14 +268,17 @@ public class SDKClient implements Closeable {
     @Deprecated
     public static class SDKRestClient implements Closeable {
 
+        private final SDKClient sdkClient;
         private final RestHighLevelClient restHighLevelClient;
 
         /**
          * Instantiate this class wrapping a {@link RestHighLevelClient}.
          *
+         * @param sdkClient The SDKClient instance.
          * @param restHighLevelClient The client to wrap.
          */
-        public SDKRestClient(RestHighLevelClient restHighLevelClient) {
+        public SDKRestClient(SDKClient sdkClient, RestHighLevelClient restHighLevelClient) {
+            this.sdkClient = sdkClient;
             this.restHighLevelClient = restHighLevelClient;
         }
 
@@ -291,6 +294,23 @@ public class SDKClient implements Closeable {
          */
         public SDKClusterAdminClient cluster() {
             return new SDKClusterAdminClient(restHighLevelClient.cluster());
+        }
+
+        /**
+         * Executes a generic action, denoted by an {@link ActionType}.
+         *
+         * @param action The action type to execute.
+         * @param request The action request.
+         * @param listener The listener to receive the response back.
+         * @param <Request> The request type.
+         * @param <Response> The response type.
+         */
+        public final <Request extends ActionRequest, Response extends ActionResponse> void execute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
+            this.sdkClient.execute(action, request, listener);
         }
 
         /**


### PR DESCRIPTION
### Description

Wraps the `SDKClient.execute()` method from the `SDKRestClient`.

### Issues Resolved

Fixes #489 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
