### PR TITLE
Force javadoc warnings as errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ task javadocStrict(type: Javadoc) {
   source = sourceSets.main.allJava
   classpath = sourceSets.main.runtimeClasspath
   options.addStringOption('Xdoclint:all', '-quiet')
+  options.addStringOption('Xwerror', '-quiet')
   options.memberLevel = JavadocMemberLevel.PRIVATE
 }
 check.dependsOn javadocStrict


### PR DESCRIPTION
### Description
Force gradle check to fail when java docs check sees warnings.
Will keep this PR in draft state until we resolve the warnings

### Issues Resolved
Part of #496 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
