### PR TITLE
Removing SafeConstructor() now that Snakeyml has been bumped up to 2.0

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -18,7 +18,6 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * This class encapsulates the settings for an Extension.
@@ -100,7 +99,7 @@ public class ExtensionSettings {
      * @throws IOException if there is an error reading the file.
      */
     public static ExtensionSettings readSettingsFromYaml(String extensionSettingsPath) throws IOException {
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml();
         URL resource = Extension.class.getResource(extensionSettingsPath);
         if (resource == null) {
             throw new IOException("extension.yml does not exist at path [" + extensionSettingsPath + "]");


### PR DESCRIPTION
### Description
Now that OpenSearch has bumped up SnakeYaml version to 2.0 we can remove SafeConstructor()

### Issues Resolved
Coming from : https://github.com/opensearch-project/OpenSearch/pull/6511

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
