### PR TITLE
Update PLUGIN_MIGRATION document with guidance on how to retrieve NamedXContentRegistry objects for created components

### DIFF
--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -47,6 +47,13 @@ this.sdkNamedXContentRegistry = extensionsRunner.getNamedXContentRegistry();
 
 When a `NamedXContentRegistry` object is required, get the current one from `this.sdkNamedXContentRegistry.getRegistry()`.
 
+When initializing objects for `createComponents`, the `SDKNamedXContentRegistry` should be passed to the component constructors. In the objects that are instantiated for `createComponents`, whenever there is an `NamedXContentRegistry` object required, call `getRegistry()` from the `SDKNamedXContentRegistry` object passed from the constructor. For example :
+```java
+XContentParser parser = XContentType.JSON
+                    .xContent()
+                    .createParser(sdkNamedXContentRegistry.getRegistry(), LoggingDeprecationHandler.INSTANCE, value);
+```
+
 Other potential initialization values:
 ```java
 this.environmentSettings = extensionsRunner.getEnvironmentSettings();


### PR DESCRIPTION
Updating plugin migration document to add guidance for how to retrieve `namedXContentRegistry` objects within created components

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
