### PR TITLE
Delay sending Settings Update Consumers until initialization

### DIFF
--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -70,7 +70,12 @@ public class ExtensionsInitRequestHandler {
             extensionsRunner.updateNamedXContentRegistry();
 
             // Last step of initialization
+            // TODO: make sure all the other sendX methods have completed
+            // https://github.com/opensearch-project/opensearch-sdk-java/issues/17
             extensionsRunner.setInitialized();
+
+            // Trigger pending updates requiring completion of the above actions
+            extensionsRunner.getSdkClusterService().getClusterSettings().sendPendingSettingsUpdateConsumers();
         }
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -22,7 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -40,6 +42,12 @@ public class TestSDKClusterService extends OpenSearchTestCase {
 
     @Test
     public void testState() throws Exception {
+        // Before initialization should throw exception
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> sdkClusterService.state());
+        assertEquals("The Extensions Runner has not been initialized.", ex.getMessage());
+
+        // After initialization should be successful
+        when(extensionsRunner.isInitialized()).thenReturn(true);
         sdkClusterService.state();
         verify(extensionsRunner, times(1)).getExtensionTransportService();
 
@@ -64,17 +72,69 @@ public class TestSDKClusterService extends OpenSearchTestCase {
     public void testAddSettingsUpdateConsumer() throws Exception {
         Setting<Boolean> boolSetting = Setting.boolSetting("test", false);
         Consumer<Boolean> boolConsumer = b -> {};
+
+        // Before initialization should store pending update but do nothing
         sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(boolSetting, boolConsumer);
+        verify(extensionsRunner, times(0)).getExtensionTransportService();
+
+        // After initialization should be able to send pending updates
+        when(extensionsRunner.isInitialized()).thenReturn(true);
+        sdkClusterService.getClusterSettings().sendPendingSettingsUpdateConsumers();
         verify(extensionsRunner, times(1)).getExtensionTransportService();
+
+        // Once updates sent, map is empty, shouldn't send on retry (keep cumulative 1)
+        sdkClusterService.getClusterSettings().sendPendingSettingsUpdateConsumers();
+        verify(extensionsRunner, times(1)).getExtensionTransportService();
+
+        // Sending a new update should send immediately (cumulative now 2)
+        sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(boolSetting, boolConsumer);
+        verify(extensionsRunner, times(2)).getExtensionTransportService();
 
         ArgumentCaptor<TransportService> transportServiceArgumentCaptor = ArgumentCaptor.forClass(TransportService.class);
         @SuppressWarnings("unchecked")
         ArgumentCaptor<Map<Setting<?>, Consumer<?>>> updateConsumerArgumentCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(extensionsRunner, times(1)).sendAddSettingsUpdateConsumerRequest(
+        verify(extensionsRunner, times(2)).sendAddSettingsUpdateConsumerRequest(
             transportServiceArgumentCaptor.capture(),
             updateConsumerArgumentCaptor.capture()
         );
         assertNull(transportServiceArgumentCaptor.getValue());
-        assertEquals(Map.of(boolSetting, boolConsumer), updateConsumerArgumentCaptor.getValue());
+        // Map will be cleared following this call
+        assertTrue(updateConsumerArgumentCaptor.getValue().isEmpty());
+    }
+
+    @Test
+    public void testAddSettingsUpdateConsumerMap() throws Exception {
+        Setting<Boolean> boolSetting = Setting.boolSetting("test", false);
+        Consumer<Boolean> boolConsumer = b -> {};
+        Map<Setting<?>, Consumer<?>> settingsUpdateConsumersMap = new HashMap<>();
+        settingsUpdateConsumersMap.put(boolSetting, boolConsumer);
+
+        // Before initialization should store pending update but do nothing
+        sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(settingsUpdateConsumersMap);
+        verify(extensionsRunner, times(0)).getExtensionTransportService();
+
+        // After initialization should be able to send pending updates
+        when(extensionsRunner.isInitialized()).thenReturn(true);
+        sdkClusterService.getClusterSettings().sendPendingSettingsUpdateConsumers();
+        verify(extensionsRunner, times(1)).getExtensionTransportService();
+
+        // Once updates sent, map is empty, shouldn't send on retry (keep cumulative 1)
+        sdkClusterService.getClusterSettings().sendPendingSettingsUpdateConsumers();
+        verify(extensionsRunner, times(1)).getExtensionTransportService();
+
+        // Sending a new update should send immediately (cumulative now 2)
+        sdkClusterService.getClusterSettings().addSettingsUpdateConsumer(settingsUpdateConsumersMap);
+        verify(extensionsRunner, times(2)).getExtensionTransportService();
+
+        ArgumentCaptor<TransportService> transportServiceArgumentCaptor = ArgumentCaptor.forClass(TransportService.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Setting<?>, Consumer<?>>> updateConsumerArgumentCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(extensionsRunner, times(2)).sendAddSettingsUpdateConsumerRequest(
+            transportServiceArgumentCaptor.capture(),
+            updateConsumerArgumentCaptor.capture()
+        );
+        assertNull(transportServiceArgumentCaptor.getValue());
+        // Map will be cleared following this call
+        assertTrue(updateConsumerArgumentCaptor.getValue().isEmpty());
     }
 }


### PR DESCRIPTION
### Description

Before `ExtensionsRunner` initialization, there is no transport service and settings have not yet been sent to OpenSearch to update.  This change adds a pending updates map to the `SDKClusterSettings` object to keep track of settings that haven't yet been sent.

### Issues Resolved

Fixes #507 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
