### PR TITLE
Added updateSettings for SDKIndicesClient

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -35,6 +35,7 @@ import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetRequest;
@@ -466,6 +467,17 @@ public class SDKClient implements Closeable {
          */
         public Cancellable delete(DeleteIndexRequest deleteIndexRequest, ActionListener<AcknowledgedResponse> listener) {
             return indicesClient.deleteAsync(deleteIndexRequest, RequestOptions.DEFAULT, listener);
+        }
+
+        /**
+         * Asynchronously updates specific index level settings using the Update Indices Settings API.
+         *
+         * @param updateSettingsRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable putSettings(UpdateSettingsRequest updateSettingsRequest, ActionListener<AcknowledgedResponse> listener) {
+            return indicesClient.putSettingsAsync(updateSettingsRequest, RequestOptions.DEFAULT, listener);
         }
 
         /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.get.MultiGetRequest;
@@ -96,6 +97,7 @@ public class TestSDKClient extends OpenSearchTestCase {
         // Would really prefer to mock/verify the method calls but the IndicesClient class is final
         assertInstanceOf(Cancellable.class, indicesClient.create(new CreateIndexRequest(""), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(Cancellable.class, indicesClient.delete(new DeleteIndexRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertInstanceOf(Cancellable.class, indicesClient.putSettings(new UpdateSettingsRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(Cancellable.class, indicesClient.getMapping(new GetMappingsRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(Cancellable.class, indicesClient.putMapping(new PutMappingRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(


### PR DESCRIPTION
### Description
`AnomalyDetectionIndices` utilizes the `IndicesAdminClient` to submit an `updateSettings` request [here](https://github.com/opensearch-project/anomaly-detection/blob/fd547014fdde5114bbc9c8e49fe7aaa37eb6e793/src/main/java/org/opensearch/ad/indices/AnomalyDetectionIndices.java#L1121) to update Job Index settings if necessary at the start of `startDetector`. 
 
The `IndicesClient` has a similar method called `putSettingsAsync` [here](https://github.com/opensearch-project/OpenSearch/blob/ee305d0b95e00e66dd20ab0a4ce6687df6cf8875/client/rest-high-level/src/main/java/org/opensearch/client/IndicesClient.java#L1307) that similarly updates index level settings. This PR adds this functionality to the `SDKIndicesClient`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
