### PR TITLE
Properly initialize SDKClient actions map

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.google.inject.Inject;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.HttpHost;
@@ -85,15 +84,19 @@ public class SDKClient implements Closeable {
     private RestClient restClient;
     private RestHighLevelClient sdkRestClient;
 
-    // Used by client.execute
+    // Used by client.execute, populated by initialize method
     @SuppressWarnings("rawtypes")
-    @Inject
     private Map<ActionType, TransportAction> actions;
 
     /**
-     * Instantiate this client.
+     * Initialize this client.
+     *
+     * @param actions The injected map of ActionType instances to TransportAction.
      */
-    public SDKClient() {}
+    @SuppressWarnings("rawtypes")
+    public void initialize(Map<ActionType, TransportAction> actions) {
+        this.actions = actions;
+    }
 
     /**
      * Create and configure a RestClientBuilder

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -254,7 +254,7 @@ public class SDKClient implements Closeable {
         ActionListener<Response> listener
     ) {
         if (actions == null) {
-            throw new IllegalStateException("SDKClient was not initialized because the Extension does not implement ActionExtession.");
+            throw new IllegalStateException("SDKClient was not initialized because the Extension does not implement ActionExtension.");
         }
         @SuppressWarnings("unchecked")
         TransportAction<Request, Response> transportAction = actions.get(action);

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -253,6 +253,9 @@ public class SDKClient implements Closeable {
         Request request,
         ActionListener<Response> listener
     ) {
+        if (actions == null) {
+            throw new IllegalStateException("SDKClient was not initialized because the Extension does not implement ActionExtession.");
+        }
         @SuppressWarnings("unchecked")
         TransportAction<Request, Response> transportAction = actions.get(action);
         if (transportAction == null) {

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -260,6 +260,6 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
             })
         );
 
-        assertEquals("SDKClient was not initialized because the Extension does not implement ActionExtession.", ex.getMessage());
+        assertEquals("SDKClient was not initialized because the Extension does not implement ActionExtension.", ex.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -237,4 +237,29 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
 
         assertEquals("failed to find action [" + UnregisteredAction.INSTANCE + "] to execute", ex.getMessage());
     }
+
+    @Test
+    public void testSdkClientNotInitialized() throws Exception {
+        String expectedName = "";
+        SampleRequest request = new SampleRequest(expectedName);
+        CompletableFuture<SampleResponse> responseFuture = new CompletableFuture<>();
+        SDKClient uninitializedSdkClient = new SDKClient();
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> uninitializedSdkClient.execute(SampleAction.INSTANCE, request, new ActionListener<SampleResponse>() {
+                @Override
+                public void onResponse(SampleResponse response) {
+                    responseFuture.complete(response);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    responseFuture.completeExceptionally(e);
+                }
+            })
+        );
+
+        assertEquals("SDKClient was not initialized because the Extension does not implement ActionExtession.", ex.getMessage());
+    }
 }

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk.sample.helloworld;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,7 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
+import org.opensearch.action.support.TransportAction;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
@@ -40,6 +42,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 
 public class TestHelloWorldExtension extends OpenSearchTestCase {
 
@@ -72,8 +75,15 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
             b.bind(TaskManager.class).toInstance(taskManager);
             b.bind(SDKClient.class);
         });
-        this.sdkClient = injector.getInstance(SDKClient.class);
+        this.sdkClient = new SDKClient();
+        initializeSdkClient();
         this.sdkRestClient = sdkClient.initializeRestClient("localhost", 9200);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private void initializeSdkClient() {
+        sdkClient.initialize(this.injector.getInstance(new Key<Map<ActionType, TransportAction>>() {
+        }));
     }
 
     @Override


### PR DESCRIPTION
### Description

Adds an `initialize()` method to the `SDKClient` to allow its `actions` map to be populated after Guice injection, even though the class was instantiated before.  This is the same pattern used with `NodeClient` that we are emulating.

In addition, maintains a field for the Guice `Injector` in the `ExtensionsRunner`.  It was getting garbage collected and losing its usefulness, particularly in Rest Handlers.

### Issues Resolved

Fixes #519

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
