### PR TITLE
Adding ExtensionsRunner parameter to getExtensionRestHandlers

### DIFF
--- a/src/main/java/org/opensearch/sdk/ActionExtension.java
+++ b/src/main/java/org/opensearch/sdk/ActionExtension.java
@@ -69,7 +69,7 @@ public interface ActionExtension {
      *
      * @return a list of REST handlers (REST actions) this extension handles.
      */
-    default List<ExtensionRestHandler> getExtensionRestHandlers() {
+    default List<ExtensionRestHandler> getExtensionRestHandlers(ExtensionsRunner extensionsRunner) {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -199,7 +199,9 @@ public class ExtensionsRunner {
             // initialize SDKClient action map
             initializeSdkClient();
             // store REST handlers in the registry
-            for (ExtensionRestHandler extensionRestHandler : ((ActionExtension) extension).getExtensionRestHandlers()) {
+            for (ExtensionRestHandler extensionRestHandler : ((ActionExtension) extension).getExtensionRestHandlers(
+                injector.getInstance(ExtensionsRunner.class)
+            )) {
                 for (Route route : extensionRestHandler.routes()) {
                     extensionRestPathRegistry.registerHandler(route.getMethod(), route.getPath(), extensionRestHandler);
                 }

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -29,7 +29,7 @@ import org.opensearch.sdk.sample.helloworld.transport.SampleTransportAction;
  * Sample class to demonstrate how to use the OpenSearch SDK for Java to create
  * an extension.
  * <p>
- * To create your own extension, implement the {@link #getExtensionSettings()} and {@link #getExtensionRestHandlers(ExtensionRunner)} methods.
+ * To create your own extension, implement the {@link #getExtensionSettings()} and {@link #getExtensionRestHandlers(ExtensionsRunner)} methods.
  * You may either create an {@link ExtensionSettings} object directly with the constructor, or read it from a YAML file on your class path.
  * <p>
  * To execute, pass an instatiated object of this class to {@link ExtensionsRunner#run(Extension)}.

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -29,7 +29,7 @@ import org.opensearch.sdk.sample.helloworld.transport.SampleTransportAction;
  * Sample class to demonstrate how to use the OpenSearch SDK for Java to create
  * an extension.
  * <p>
- * To create your own extension, implement the {@link #getExtensionSettings()} and {@link #getExtensionRestHandlers()} methods.
+ * To create your own extension, implement the {@link #getExtensionSettings()} and {@link #getExtensionRestHandlers(ExtensionRunner)} methods.
  * You may either create an {@link ExtensionSettings} object directly with the constructor, or read it from a YAML file on your class path.
  * <p>
  * To execute, pass an instatiated object of this class to {@link ExtensionsRunner#run(Extension)}.
@@ -53,7 +53,7 @@ public class HelloWorldExtension extends BaseExtension {
     }
 
     @Override
-    public List<ExtensionRestHandler> getExtensionRestHandlers() {
+    public List<ExtensionRestHandler> getExtensionRestHandlers(ExtensionsRunner extensionsRunner) {
         return List.of(new RestHelloAction());
     }
 

--- a/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionInterfaces.java
@@ -10,6 +10,7 @@
 package org.opensearch.sdk;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.common.settings.Settings;
@@ -34,13 +35,15 @@ public class TestExtensionInterfaces extends OpenSearchTestCase {
 
     @Test
     void testActionExtension() {
+
+        ExtensionsRunner extensionsRunner = mock(ExtensionsRunner.class);
         ActionExtension actionExtension = new ActionExtension() {
         };
 
         assertTrue(actionExtension.getActions().isEmpty());
         assertTrue(actionExtension.getClientActions().isEmpty());
         assertTrue(actionExtension.getActionFilters().isEmpty());
-        assertTrue(actionExtension.getExtensionRestHandlers().isEmpty());
+        assertTrue(actionExtension.getExtensionRestHandlers(extensionsRunner).isEmpty());
         assertTrue(actionExtension.getRestHeaders().isEmpty());
         assertTrue(actionExtension.getTaskHeaders().isEmpty());
         assertDoesNotThrow(() -> actionExtension.getRestHandlerWrapper(null));


### PR DESCRIPTION
### Description
Provides the ExtensionRunner to getExtensionsRestHandlers. This allows us to pass in the same instance of the extension runner to all registered rest actions.

Companion PR : https://github.com/opensearch-project/anomaly-detection/pull/835

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
