### PR TITLE
[Backport 1.x] Add empty or custom SDKNamedXContentRegistry

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
+++ b/src/main/java/org/opensearch/sdk/SDKNamedXContentRegistry.java
@@ -20,6 +20,7 @@ import org.opensearch.cluster.ClusterModule;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
+import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.NamedXContentRegistry.Entry;
 import org.opensearch.indices.IndicesModule;
 import org.opensearch.search.SearchModule;
@@ -28,7 +29,23 @@ import org.opensearch.search.SearchModule;
  * Combines Extension NamedXContent with core OpenSearch NamedXContent
  */
 public class SDKNamedXContentRegistry {
+    /**
+     * The empty {@link SDKNamedXContentRegistry} for use when you are sure that you aren't going to call
+     * {@link XContentParser#namedObject(Class, String, Object)}. Be *very* careful with this singleton because a parser using it will fail
+     * every call to {@linkplain XContentParser#namedObject(Class, String, Object)}. Every non-test usage really should be checked
+     * thoroughly and marked with a comment about how it was checked. That way anyone that sees code that uses it knows that it is
+     * potentially dangerous.
+     */
+    public static final SDKNamedXContentRegistry EMPTY = new SDKNamedXContentRegistry();
+
     private NamedXContentRegistry namedXContentRegistry;
+
+    /**
+     * Creates an empty registry.
+     */
+    private SDKNamedXContentRegistry() {
+        this.namedXContentRegistry = NamedXContentRegistry.EMPTY;
+    }
 
     /**
      * Creates and populates a NamedXContentRegistry with the NamedXContentRegistry entries for this extension and locally defined content.
@@ -70,5 +87,14 @@ public class SDKNamedXContentRegistry {
      */
     public NamedXContentRegistry getRegistry() {
         return this.namedXContentRegistry;
+    }
+
+    /**
+     * Sets the NamedXContentRegistry. Used primarily for tests.
+     *
+     * @param namedXContentRegistry The registry to set.
+     */
+    public void setRegistry(NamedXContentRegistry namedXContentRegistry) {
+        this.namedXContentRegistry = namedXContentRegistry;
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKNamedXContentRegistry.java
@@ -163,4 +163,15 @@ public class TestSDKNamedXContentRegistry extends OpenSearchTestCase {
         Example example = registry.parseNamedObject(Example.class, Example.NAME, parser, null);
         assertEquals(Example.NAME, example.getName());
     }
+
+    @Test
+    public void testEmptyRegistry() {
+        assertEquals(NamedXContentRegistry.EMPTY, SDKNamedXContentRegistry.EMPTY.getRegistry());
+    }
+
+    @Test
+    public void testSetRegistry() {
+        runner.sdkNamedXContentRegistry.setRegistry(NamedXContentRegistry.EMPTY);
+        assertEquals(NamedXContentRegistry.EMPTY, runner.sdkNamedXContentRegistry.getRegistry());
+    }
 }


### PR DESCRIPTION
### Description

The Anomaly Detection project test framework makes frequent use of `NamedXContentRegistry.EMPTY` in constructors for test instances, or provides a minimal registry created from other sources.

Since the constructors will be taking `SDKNamedXConetentRegistry` parameters as part of #518, we need an equivalent to pass for either the `EMPTY` case or to set a custom internal registry.

Backport of https://github.com/opensearch-project/opensearch-sdk-java/pull/529

### Issues Resolved

Part of #518 with the remainder of the work on AD Extension repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
