### PR TITLE
Always initialize SDKActionModule

### DIFF
--- a/src/main/java/org/opensearch/sdk/BaseExtension.java
+++ b/src/main/java/org/opensearch/sdk/BaseExtension.java
@@ -16,7 +16,7 @@ import com.google.inject.Inject;
 /**
  * An abstract class that simplifies extension initialization and provides an instance of the runner.
  */
-public abstract class BaseExtension implements Extension, ActionExtension {
+public abstract class BaseExtension implements Extension {
     /**
      * The {@link ExtensionsRunner} instance running this extension
      */

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -86,7 +87,7 @@ public class SDKClient implements Closeable {
 
     // Used by client.execute, populated by initialize method
     @SuppressWarnings("rawtypes")
-    private Map<ActionType, TransportAction> actions;
+    private Map<ActionType, TransportAction> actions = Collections.emptyMap();
 
     /**
      * Initialize this client.

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -62,14 +62,12 @@ public class ExtensionsInitRequestHandler {
             extensionTransportService.connectToNode(extensionsRunner.opensearchNode);
             extensionsRunner.sendRegisterRestActionsRequest(extensionTransportService);
             extensionsRunner.sendRegisterCustomSettingsRequest(extensionTransportService);
-            if (extensionsRunner.getSdkActionModule() != null) {
-                extensionsRunner.getSdkActionModule()
-                    .sendRegisterTransportActionsRequest(
-                        extensionTransportService,
-                        extensionsRunner.opensearchNode,
-                        extensionsRunner.getUniqueId()
-                    );
-            }
+            extensionsRunner.getSdkActionModule()
+                .sendRegisterTransportActionsRequest(
+                    extensionTransportService,
+                    extensionsRunner.opensearchNode,
+                    extensionsRunner.getUniqueId()
+                );
             // Get OpenSearch Settings and set values on ExtensionsRunner
             Settings settings = extensionsRunner.sendEnvironmentSettingsRequest(extensionTransportService);
             extensionsRunner.setEnvironmentSettings(settings);

--- a/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
+++ b/src/main/java/org/opensearch/sdk/sample/helloworld/HelloWorldExtension.java
@@ -20,6 +20,7 @@ import org.opensearch.sdk.Extension;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.sdk.ExtensionSettings;
 import org.opensearch.sdk.ExtensionsRunner;
+import org.opensearch.sdk.ActionExtension;
 import org.opensearch.sdk.ActionExtension.ActionHandler;
 import org.opensearch.sdk.sample.helloworld.rest.RestHelloAction;
 import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
@@ -34,7 +35,7 @@ import org.opensearch.sdk.sample.helloworld.transport.SampleTransportAction;
  * <p>
  * To execute, pass an instatiated object of this class to {@link ExtensionsRunner#run(Extension)}.
  */
-public class HelloWorldExtension extends BaseExtension {
+public class HelloWorldExtension extends BaseExtension implements ActionExtension {
 
     /**
      * Optional classpath-relative path to a yml file containing extension settings.

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -240,9 +240,8 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     @Test
     public void testGetExtensionImplementedInterfaces() {
         List<String> implementedInterfaces = extensionsRunner.getExtensionImplementedInterfaces();
-        assertTrue(!implementedInterfaces.isEmpty());
+        assertFalse(implementedInterfaces.isEmpty());
         assertTrue(implementedInterfaces.contains("Extension"));
-        assertTrue(implementedInterfaces.contains("ActionExtension"));
     }
 
 }

--- a/src/test/java/org/opensearch/sdk/action/TestSDKActionModule.java
+++ b/src/test/java/org/opensearch/sdk/action/TestSDKActionModule.java
@@ -22,6 +22,8 @@ import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.extensions.RegisterTransportActionsRequest;
 import org.opensearch.sdk.ActionExtension;
+import org.opensearch.sdk.Extension;
+import org.opensearch.sdk.ExtensionSettings;
 import org.opensearch.sdk.handlers.AcknowledgedResponseHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;
@@ -51,7 +53,12 @@ public class TestSDKActionModule extends OpenSearchTestCase {
     private TransportService transportService;
     private DiscoveryNode opensearchNode;
 
-    private SDKActionModule sdkActionModule = new SDKActionModule(new ActionExtension() {
+    private static class TestActionExtension implements Extension, ActionExtension {
+        @Override
+        public ExtensionSettings getExtensionSettings() {
+            return null;
+        }
+
         @Override
         public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
             @SuppressWarnings("unchecked")
@@ -60,7 +67,9 @@ public class TestSDKActionModule extends OpenSearchTestCase {
 
             return Arrays.asList(new ActionHandler<ActionRequest, ActionResponse>(testAction, null));
         }
-    });
+    }
+
+    private SDKActionModule sdkActionModule = new SDKActionModule(new TestActionExtension());
 
     @Override
     @BeforeEach

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -237,29 +237,4 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
 
         assertEquals("failed to find action [" + UnregisteredAction.INSTANCE + "] to execute", ex.getMessage());
     }
-
-    @Test
-    public void testSdkClientNotInitialized() throws Exception {
-        String expectedName = "";
-        SampleRequest request = new SampleRequest(expectedName);
-        CompletableFuture<SampleResponse> responseFuture = new CompletableFuture<>();
-        SDKClient uninitializedSdkClient = new SDKClient();
-
-        IllegalStateException ex = assertThrows(
-            IllegalStateException.class,
-            () -> uninitializedSdkClient.execute(SampleAction.INSTANCE, request, new ActionListener<SampleResponse>() {
-                @Override
-                public void onResponse(SampleResponse response) {
-                    responseFuture.complete(response);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    responseFuture.completeExceptionally(e);
-                }
-            })
-        );
-
-        assertEquals("SDKClient was not initialized because the Extension does not implement ActionExtension.", ex.getMessage());
-    }
 }


### PR DESCRIPTION
### Description

Improves on #520 

 - Always initializes the `SDKActionModule`, handling internals with sensible (empty) defaults
 - Removes (no longer necessary) null checks and Nullable annotations
 - Addresses [this comment](https://github.com/opensearch-project/opensearch-sdk-java/pull/520#discussion_r1125032683) by simply returning action not registered exception, removing separate exception handling for nulls.
 - `BaseExtension` no longer `implements ActionExtension`

### Issues Resolved

Partial implementation of #525 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
