### PR TITLE
Integrated Async Java Client

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -166,7 +166,7 @@ public class SDKClient implements Closeable {
      *
      * @param settings The Extension settings
      * @return The SDKClient implementation of OpenSearchClient. The user is responsible for calling
-     *         {@link #doCloseJavaClient()} when finished with the client
+     *         {@link #doCloseJavaClients()} when finished with the client
      */
     public OpenSearchClient initializeJavaClient(ExtensionSettings settings) {
         return initializeJavaClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
@@ -178,7 +178,7 @@ public class SDKClient implements Closeable {
      * @param hostAddress The address of OpenSearch cluster, client can connect to
      * @param port The port of OpenSearch cluster
      * @return The SDKClient implementation of OpenSearchClient. The user is responsible for calling
-     *         {@link #doCloseJavaClient()} when finished with the client
+     *         {@link #doCloseJavaClients()} when finished with the client
      */
     public OpenSearchClient initializeJavaClient(String hostAddress, int port) {
         OpenSearchTransport transport = initializeTransport(hostAddress, port);
@@ -191,7 +191,7 @@ public class SDKClient implements Closeable {
      *
      * @param settings The Extension settings
      * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
-     *         {@link #doCloseJavaClient()} when finished with the client
+     *         {@link #doCloseJavaClients()} when finished with the client as JavaClient and JavaAsyncClient uses the same close method
      */
     public OpenSearchAsyncClient initializeJavaAsyncClient(ExtensionSettings settings) {
         return initalizeJavaAsyncClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
@@ -203,7 +203,7 @@ public class SDKClient implements Closeable {
      * @param hostAddress The address of OpenSearch cluster, client can connect to
      * @param port The port of OpenSearch cluster
      * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
-     *         {@link #doCloseJavaClient()} when finished with the client
+     *         {@link #doCloseJavaClients()} when finished with the client
      */
     public OpenSearchAsyncClient initalizeJavaAsyncClient(String hostAddress, int port) {
         OpenSearchTransport transport = initializeTransport(hostAddress, port);
@@ -255,7 +255,7 @@ public class SDKClient implements Closeable {
      *
      * @throws IOException if closing the restClient fails
      */
-    public void doCloseJavaClient() throws IOException {
+    public void doCloseJavaClients() throws IOException {
         if (restClient != null) {
             restClient.close();
         }
@@ -274,7 +274,7 @@ public class SDKClient implements Closeable {
 
     @Override
     public void close() throws IOException {
-        doCloseJavaClient();
+        doCloseJavaClients();
         doCloseHighLevelClient();
     }
 

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -173,17 +173,6 @@ public class SDKClient implements Closeable {
     }
 
     /**
-     * Initializes an OpenAsyncSearchClient using OpenSearch JavaClient
-     *
-     * @param settings The Extension settings
-     * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
-     *         {@link #doCloseJavaClient()} when finished with the client
-     */
-    public OpenSearchAsyncClient initializeJavaAsyncClient(ExtensionSettings settings) {
-        return initalizeJavaAsyncClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
-    }
-
-    /**
      * Initializes an OpenSearchClient using OpenSearch JavaClient
      *
      * @param hostAddress The address of OpenSearch cluster, client can connect to
@@ -195,6 +184,17 @@ public class SDKClient implements Closeable {
         OpenSearchTransport transport = initializeTransport(hostAddress, port);
         javaClient = new OpenSearchClient(transport);
         return javaClient;
+    }
+
+    /**
+     * Initializes an OpenAsyncSearchClient using OpenSearch JavaClient
+     *
+     * @param settings The Extension settings
+     * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
+     *         {@link #doCloseJavaClient()} when finished with the client
+     */
+    public OpenSearchAsyncClient initializeJavaAsyncClient(ExtensionSettings settings) {
+        return initalizeJavaAsyncClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -71,6 +71,7 @@ import org.opensearch.client.indices.PutMappingRequest;
 import org.opensearch.client.indices.rollover.RolloverRequest;
 import org.opensearch.client.indices.rollover.RolloverResponse;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.rest_client.RestClientTransport;
@@ -84,6 +85,7 @@ public class SDKClient implements Closeable {
     private OpenSearchClient javaClient;
     private RestClient restClient;
     private RestHighLevelClient sdkRestClient;
+    private OpenSearchAsyncClient javaAsyncClient;
 
     // Used by client.execute, populated by initialize method
     @SuppressWarnings("rawtypes")
@@ -137,6 +139,29 @@ public class SDKClient implements Closeable {
     }
 
     /**
+     * Initializes an OpenSearchTransport using RestClientTransport. This is required for JavaClient and JavaAsyncClient
+     *
+     * @param hostAddress The address of OpenSearch cluster, client can connect to
+     * @param port The port of OpenSearch cluster
+     * @return The OpenSearchTransport implementation of RestClientTransport.
+     */
+    private OpenSearchTransport initializeTransport(String hostAddress, int port) {
+        RestClientBuilder builder = builder(hostAddress, port);
+
+        restClient = builder.build();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new GuavaModule());
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, JsonTypeInfo.As.PROPERTY);
+        mapper.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        // Create Client
+        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper(mapper));
+        return transport;
+    }
+
+    /**
      * Initializes an OpenSearchClient using OpenSearch JavaClient
      *
      * @param settings The Extension settings
@@ -148,6 +173,17 @@ public class SDKClient implements Closeable {
     }
 
     /**
+     * Initializes an OpenAsyncSearchClient using OpenSearch JavaClient
+     *
+     * @param settings The Extension settings
+     * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
+     *         {@link #doCloseJavaClient()} when finished with the client
+     */
+    public OpenSearchAsyncClient initializeJavaAsyncClient(ExtensionSettings settings) {
+        return initalizeJavaAsyncClient(settings.getOpensearchAddress(), Integer.parseInt(settings.getOpensearchPort()));
+    }
+
+    /**
      * Initializes an OpenSearchClient using OpenSearch JavaClient
      *
      * @param hostAddress The address of OpenSearch cluster, client can connect to
@@ -156,21 +192,23 @@ public class SDKClient implements Closeable {
      *         {@link #doCloseJavaClient()} when finished with the client
      */
     public OpenSearchClient initializeJavaClient(String hostAddress, int port) {
-        RestClientBuilder builder = builder(hostAddress, port);
-
-        restClient = builder.build();
-
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.registerModule(new GuavaModule());
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.OBJECT_AND_NON_CONCRETE, JsonTypeInfo.As.PROPERTY);
-        mapper.configure(MapperFeature.USE_GETTERS_AS_SETTERS, false);
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
-        // Create Client
-        OpenSearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper(mapper));
+        OpenSearchTransport transport = initializeTransport(hostAddress, port);
         javaClient = new OpenSearchClient(transport);
         return javaClient;
+    }
+
+    /**
+     * Initializes an OpenAsyncSearchClient using OpenSearch JavaClient
+     *
+     * @param hostAddress The address of OpenSearch cluster, client can connect to
+     * @param port The port of OpenSearch cluster
+     * @return The SDKClient implementation of OpenSearchAsyncClient. The user is responsible for calling
+     *         {@link #doCloseJavaClient()} when finished with the client
+     */
+    public OpenSearchAsyncClient initalizeJavaAsyncClient(String hostAddress, int port) {
+        OpenSearchTransport transport = initializeTransport(hostAddress, port);
+        javaAsyncClient = new OpenSearchAsyncClient(transport);
+        return javaAsyncClient;
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -63,7 +63,7 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertInstanceOf(OpenSearchIndicesClient.class, javaClient.indices());
         assertInstanceOf(OpenSearchClusterClient.class, javaClient.cluster());
 
-        sdkClient.doCloseJavaClient();
+        sdkClient.doCloseJavaClients();
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertInstanceOf(OpenSearchIndicesAsyncClient.class, javaAsyncClient.indices());
         assertInstanceOf(OpenSearchClusterAsyncClient.class, javaAsyncClient.cluster());
 
-        sdkClient.doCloseJavaClient();
+        sdkClient.doCloseJavaClients();
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -26,8 +26,11 @@ import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.PutMappingRequest;
 import org.opensearch.client.indices.rollover.RolloverRequest;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.cluster.OpenSearchClusterAsyncClient;
 import org.opensearch.client.opensearch.cluster.OpenSearchClusterClient;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
 import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
 import org.opensearch.sdk.SDKClient.SDKClusterAdminClient;
 import org.opensearch.sdk.SDKClient.SDKIndicesClient;
@@ -59,6 +62,15 @@ public class TestSDKClient extends OpenSearchTestCase {
         OpenSearchClient javaClient = sdkClient.initializeJavaClient(settings);
         assertInstanceOf(OpenSearchIndicesClient.class, javaClient.indices());
         assertInstanceOf(OpenSearchClusterClient.class, javaClient.cluster());
+
+        sdkClient.doCloseJavaClient();
+    }
+
+    @Test
+    public void testCreateJavaAsyncClient() throws Exception {
+        OpenSearchAsyncClient javaAsyncClient = sdkClient.initializeJavaAsyncClient(settings);
+        assertInstanceOf(OpenSearchIndicesAsyncClient.class, javaAsyncClient.indices());
+        assertInstanceOf(OpenSearchClusterAsyncClient.class, javaAsyncClient.cluster());
 
         sdkClient.doCloseJavaClient();
     }


### PR DESCRIPTION
### Description
To invoke the Actions residing in OpenSearch. Extensions will use Java Client to call the action using REST requests available. Currently, we support synchronous Java Client. As AD plugin uses asynchronous request calls, create an async Java Client for the same.

This is needed for the migration of [Start Detector](https://github.com/opensearch-project/opensearch-sdk-java/issues/383).

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/557
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/296

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
