### PR TITLE
Change SDKClusterSettings constructor to use same params as ClusterSettings

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -130,8 +130,8 @@ public class ExtensionsRunner {
     private final Injector injector;
 
     private final SDKNamedXContentRegistry sdkNamedXContentRegistry;
-    private final SDKClient sdkClient = new SDKClient();
-    private final SDKClusterService sdkClusterService = new SDKClusterService(this);
+    private final SDKClient sdkClient;
+    private final SDKClusterService sdkClusterService;
     private final SDKActionModule sdkActionModule;
 
     private ExtensionsInitRequestHandler extensionsInitRequestHandler = new ExtensionsInitRequestHandler(this);
@@ -171,6 +171,12 @@ public class ExtensionsRunner {
         this.customNamedXContent = extension.getNamedXContent();
         // initialize NamedXContent Registry. Must happen after getting extension namedXContent
         this.sdkNamedXContentRegistry = new SDKNamedXContentRegistry(this);
+        // initialize SDKClient. Must happen after getting extensionSettings
+        // TODO add a parameter to pass extensionSettings to the client to use for host/port settings
+        // https://github.com/opensearch-project/opensearch-sdk-java/issues/556
+        this.sdkClient = new SDKClient();
+        // initialize SDKClusterService. Must happen after extension field assigned
+        this.sdkClusterService = new SDKClusterService(this);
 
         // Create Guice modules for injection
         List<com.google.inject.Module> modules = new ArrayList<>();
@@ -617,6 +623,13 @@ public class ExtensionsRunner {
 
     public SDKClusterService getSdkClusterService() {
         return sdkClusterService;
+    }
+
+    /**
+     * Updates the SDKClusterService. Called from {@link ExtensionsInitRequestHandler}.
+     */
+    public void updateSdkClusterService() {
+        this.sdkClusterService.updateSdkClusterSettings();
     }
 
     public SDKActionModule getSdkActionModule() {

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -71,6 +71,7 @@ public class SDKClusterService {
      */
     public void updateSdkClusterSettings() {
         this.clusterSettings.applySettings(extensionsRunner.getEnvironmentSettings());
+        extensionsRunner.getExtension().getSettings().stream().forEach(clusterSettings::registerSetting);
     }
 
     public SDKClusterSettings getClusterSettings() {

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -9,12 +9,19 @@
 
 package org.opensearch.sdk;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.SettingUpgrader;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.AbstractScopedSettings;
+import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.extensions.DiscoveryExtensionNode;
 
 /**
@@ -32,7 +39,10 @@ public class SDKClusterService {
      */
     public SDKClusterService(ExtensionsRunner extensionsRunner) {
         this.extensionsRunner = extensionsRunner;
-        this.clusterSettings = new SDKClusterSettings();
+        // This will be empty on initialization, but updated later via apply()
+        Settings nodeSettings = extensionsRunner.getEnvironmentSettings();
+        Set<Setting<?>> settingsSet = new HashSet<>(extensionsRunner.getExtension().getSettings());
+        this.clusterSettings = new SDKClusterSettings(nodeSettings, settingsSet);
     }
 
     /**
@@ -56,6 +66,13 @@ public class SDKClusterService {
         return extensionsRunner.getExtensionNode();
     }
 
+    /**
+     * Updates cluster settings with current environment settings on the extensions runner.
+     */
+    public void updateSdkClusterSettings() {
+        this.clusterSettings.applySettings(extensionsRunner.getEnvironmentSettings());
+    }
+
     public SDKClusterSettings getClusterSettings() {
         return clusterSettings;
     }
@@ -63,12 +80,37 @@ public class SDKClusterService {
     /**
      * This class simulates methods normally called from OpenSearch ClusterSettings class.
      */
-    public class SDKClusterSettings {
+    public class SDKClusterSettings extends AbstractScopedSettings {
 
         /**
          * Thread-safe map to hold pending updates until initialization completes
          */
-        private Map<Setting<?>, Consumer<?>> pendingSettingsUpdateConsumers = new ConcurrentHashMap<>();
+        private final Map<Setting<?>, Consumer<?>> pendingSettingsUpdateConsumers = new ConcurrentHashMap<>();
+
+        /**
+         * Instantiate a new ClusterSettings instance.
+         *
+         * @param nodeSettings Environment settings associated with the node. Currently unused on extensions, provided for code compatibility.
+         * @param settingsSet The extension's settings.
+         */
+        public SDKClusterSettings(final Settings nodeSettings, final Set<Setting<?>> settingsSet) {
+            this(nodeSettings, settingsSet, Collections.emptySet());
+        }
+
+        /**
+         * Instantiate a new ClusterSettings instance.
+         *
+         * @param nodeSettings Environment settings associated with the node. Currently unused on extensions, provided for code compatibility.
+         * @param settingsSet The extension's settings.
+         * @param settingUpgraders The extension's setting upgraders.
+         */
+        public SDKClusterSettings(
+            final Settings nodeSettings,
+            final Set<Setting<?>> settingsSet,
+            final Set<SettingUpgrader<?>> settingUpgraders
+        ) {
+            super(nodeSettings, settingsSet, settingUpgraders, Property.NodeScope);
+        }
 
         /**
          * Add a single settings update consumer to OpenSearch. Before initialization the update will be stored in a pending state.

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -72,6 +72,7 @@ public class ExtensionsInitRequestHandler {
             Settings settings = extensionsRunner.sendEnvironmentSettingsRequest(extensionTransportService);
             extensionsRunner.setEnvironmentSettings(settings);
             extensionsRunner.updateNamedXContentRegistry();
+            extensionsRunner.updateSdkClusterService();
 
             // Last step of initialization
             // TODO: make sure all the other sendX methods have completed

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -37,6 +37,7 @@ public class TestSDKClusterService extends OpenSearchTestCase {
     public void setUp() throws Exception {
         super.setUp();
         this.extensionsRunner = mock(ExtensionsRunner.class);
+        when(extensionsRunner.getExtension()).thenReturn(new ExtensionsRunnerForTest().getExtension());
         this.sdkClusterService = new SDKClusterService(extensionsRunner);
     }
 


### PR DESCRIPTION
### Description

Updates the `SDKClusterSettings` class to use the same constructor arguments as the `ClusterSettings` class.

NOTE: This will break current AnomalyDetection implementations using a no-arg constructor.  I will be submitting a companion PR on AD soon, but this will need to be merged first.

### Issues Resolved

Fixes #503 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
