### PR TITLE
[FEATURE] Create ReloadableExtension interface

### DIFF
--- a/src/main/java/org/opensearch/sdk/ReloadableExtension.java
+++ b/src/main/java/org/opensearch/sdk/ReloadableExtension.java
@@ -10,16 +10,16 @@
 package org.opensearch.sdk;
 
 import org.opensearch.common.settings.Settings;
- 
+  
 /**
-* An extension point for {@link Plugin}s that can be reloaded. There is no
-* clear definition about what reloading a plugin actually means. When a plugin
-* is reloaded it might rebuild any internal members. Plugins usually implement
-* this interface in order to reread the values of {@code SecureSetting}s and
-* then rebuild any dependent internal members.
-*/
+ * An extension point for {@link Plugin}s that can be reloaded. There is no
+ * clear definition about what reloading a plugin actually means. When a plugin
+ * is reloaded it might rebuild any internal members. Plugins usually implement
+ * this interface in order to reread the values of {@code SecureSetting}s and
+ * then rebuild any dependent internal members.
+ */
 public interface ReloadableExtension {
-     
+      
     /**
      * Called to trigger the rebuilt of the plugin's internal members. The reload
      * operation <b>is required to have been completed</b> when the method returns.
@@ -41,6 +41,6 @@ public interface ReloadableExtension {
      *             if the operation failed. The plugin should continue to operate as
      *             if the offending call didn't happen.
      */
- 
+  
     void reload(Settings settings) throws Exception;
-}
+ }

--- a/src/main/java/org/opensearch/sdk/ReloadableExtension.java
+++ b/src/main/java/org/opensearch/sdk/ReloadableExtension.java
@@ -12,33 +12,33 @@ package org.opensearch.sdk;
 import org.opensearch.common.settings.Settings;
 
 /**
- * An extension point for {@link Plugin}s that can be reloaded. There is no
- * clear definition about what reloading a plugin actually means. When a plugin
- * is reloaded it might rebuild any internal members. Plugins usually implement
+ * An extension point for {@link Extension}s that can be reloaded. There is no
+ * clear definition about what reloading a extension actually means. When a extension
+ * is reloaded it might rebuild any internal members. Extensions usually implement
  * this interface in order to reread the values of {@code SecureSetting}s and
  * then rebuild any dependent internal members.
  */
 public interface ReloadableExtension {
 
     /**
-     * Called to trigger the rebuilt of the plugin's internal members. The reload
+     * Called to trigger the rebuilt of the extension's internal members. The reload
      * operation <b>is required to have been completed</b> when the method returns.
      * Strictly speaking, the <code>settings</code> argument should not be accessed
      * outside of this method's call stack, as any values stored in the node's
      * keystore (see {@code SecureSetting}) will not otherwise be retrievable. The
      * setting values do not follow dynamic updates, i.e. the values are identical
-     * to the ones during the initial plugin loading, barring the keystore file on
+     * to the ones during the initial extension loading, barring the keystore file on
      * disk changes. Any failure during the operation should be signaled by raising
-     * an exception, but the plugin should otherwise continue to function
+     * an exception, but the extension should otherwise continue to function
      * unperturbed.
      *
      * @param settings
-     *            Settings used while reloading the plugin. All values are
+     *            Settings used while reloading the extension. All values are
      *            retrievable, including the values stored in the node's keystore.
      *            The setting values are the initial ones, from when the node has be
      *            started, i.e. they don't follow dynamic updates.
      * @throws Exception
-     *             if the operation failed. The plugin should continue to operate as
+     *             if the operation failed. The extension should continue to operate as
      *             if the offending call didn't happen.
      */
 

--- a/src/main/java/org/opensearch/sdk/ReloadableExtension.java
+++ b/src/main/java/org/opensearch/sdk/ReloadableExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk;
+
+import org.opensearch.common.settings.Settings;
+ 
+/**
+* An extension point for {@link Plugin}s that can be reloaded. There is no
+* clear definition about what reloading a plugin actually means. When a plugin
+* is reloaded it might rebuild any internal members. Plugins usually implement
+* this interface in order to reread the values of {@code SecureSetting}s and
+* then rebuild any dependent internal members.
+*/
+public interface ReloadableExtension {
+     
+    /**
+     * Called to trigger the rebuilt of the plugin's internal members. The reload
+     * operation <b>is required to have been completed</b> when the method returns.
+     * Strictly speaking, the <code>settings</code> argument should not be accessed
+     * outside of this method's call stack, as any values stored in the node's
+     * keystore (see {@code SecureSetting}) will not otherwise be retrievable. The
+     * setting values do not follow dynamic updates, i.e. the values are identical
+     * to the ones during the initial plugin loading, barring the keystore file on
+     * disk changes. Any failure during the operation should be signaled by raising
+     * an exception, but the plugin should otherwise continue to function
+     * unperturbed.
+     *
+     * @param settings
+     *            Settings used while reloading the plugin. All values are
+     *            retrievable, including the values stored in the node's keystore.
+     *            The setting values are the initial ones, from when the node has be
+     *            started, i.e. they don't follow dynamic updates.
+     * @throws Exception
+     *             if the operation failed. The plugin should continue to operate as
+     *             if the offending call didn't happen.
+     */
+ 
+    void reload(Settings settings) throws Exception;
+}

--- a/src/main/java/org/opensearch/sdk/ReloadableExtension.java
+++ b/src/main/java/org/opensearch/sdk/ReloadableExtension.java
@@ -10,7 +10,7 @@
 package org.opensearch.sdk;
 
 import org.opensearch.common.settings.Settings;
-  
+
 /**
  * An extension point for {@link Plugin}s that can be reloaded. There is no
  * clear definition about what reloading a plugin actually means. When a plugin
@@ -19,7 +19,7 @@ import org.opensearch.common.settings.Settings;
  * then rebuild any dependent internal members.
  */
 public interface ReloadableExtension {
-      
+
     /**
      * Called to trigger the rebuilt of the plugin's internal members. The reload
      * operation <b>is required to have been completed</b> when the method returns.
@@ -41,6 +41,6 @@ public interface ReloadableExtension {
      *             if the operation failed. The plugin should continue to operate as
      *             if the offending call didn't happen.
      */
-  
+
     void reload(Settings settings) throws Exception;
- }
+}


### PR DESCRIPTION
### Description
Extension points (see https://github.com/opensearch-project/opensearch-sdk-java/issues/315) will be (optionally) implemented on Extensions. Eventually these points may need to be communicated to OpenSearch to be registered in the appropriate service or module.

Allowing extensions to inherit from appropriate interfaces depending on their type will match the current Plugin implementation.

### Issues Resolved
Added a new interface that was copied from ReloadablePlugin.java

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
