### PR TITLE
Added github-merit-badger for SDK

### DIFF
--- a/.github/workflows/github-merit-badger.yml
+++ b/.github/workflows/github-merit-badger.yml
@@ -1,0 +1,20 @@
+name: github-merit-badger
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  call-action:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: aws-github-ops/github-merit-badger@v0.0.98
+        id: merit-badger
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          badges: '[first-time-contributor,repeat-contributor,valued-contributor,seasoned-contributor,all-star-contributor,distinguished-contributor]'
+          thresholds: '[0,3,6,10,20,30]'
+          badge-type: 'achievement'
+          ignore-usernames: '[opensearch-ci-bot, dependabot, opensearch-trigger-bot, mend-for-github-com]'


### PR DESCRIPTION
### Description
With SDK repo getting new external contributors. This bagde will assign achievement badge to contributors based on the number of the contributions. Also, will help us to keep the track of the contributions.

Tested here: [Sample Job](https://github.com/owaiskazi19/OpenSearch/actions/runs/4421563834/jobs/7752499295) for Opensearch

Will look like this:
![Screenshot 2023-03-14 at 6 07 02 PM](https://user-images.githubusercontent.com/16099877/225178073-6d460e64-aa8b-49f9-942c-c34e79704fff.png)

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
