### PR TITLE
Adds getExecutorBuilders and indexNameExpressionResolver to extensionsRunner

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -154,7 +154,6 @@ public class ExtensionsRunner {
         new ExtensionsIndicesModuleNameRequestHandler();
     private final ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
     private final ExtensionActionRequestHandler extensionsActionRequestHandler;
-    private final List<ExecutorBuilder<?>> executorBuilders;
     private final AtomicReference<RunnableTaskExecutionListener> runnableTaskListener;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
@@ -184,9 +183,9 @@ public class ExtensionsRunner {
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
             .build();
 
-        this.executorBuilders = extension.getExecutorBuilders(settings);
+        final List<ExecutorBuilder<?>> executorBuilders = extension.getExecutorBuilders(settings);
 
-        runnableTaskListener = new AtomicReference<>();
+        this.runnableTaskListener = new AtomicReference<>();
         this.threadPool = new ThreadPool(settings, runnableTaskListener, executorBuilders.toArray(new ExecutorBuilder[0]));
         this.indexNameExpressionResolver = new IndexNameExpressionResolver(this.threadPool.getThreadContext());
         this.taskManager = new TaskManager(settings, threadPool, Collections.emptySet());

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -154,6 +154,7 @@ public class ExtensionsRunner {
         new ExtensionsIndicesModuleNameRequestHandler();
     private final ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
     private final ExtensionActionRequestHandler extensionsActionRequestHandler;
+    private final List<ExecutorBuilder<?>> executorBuilders;
     private final AtomicReference<RunnableTaskExecutionListener> runnableTaskListener;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
 
@@ -183,7 +184,7 @@ public class ExtensionsRunner {
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
             .build();
 
-        final List<ExecutorBuilder<?>> executorBuilders = extension.getExecutorBuilders(settings);
+        this.executorBuilders = extension.getExecutorBuilders(settings);
 
         runnableTaskListener = new AtomicReference<>();
         this.threadPool = new ThreadPool(settings, runnableTaskListener, executorBuilders.toArray(new ExecutorBuilder[0]));
@@ -214,11 +215,11 @@ public class ExtensionsRunner {
         modules.add(b -> {
             b.bind(ExtensionsRunner.class).toInstance(this);
             b.bind(Extension.class).toInstance(extension);
-            b.bind(IndexNameExpressionResolver.class).toInstance(indexNameExpressionResolver);
 
             b.bind(SDKNamedXContentRegistry.class).toInstance(getNamedXContentRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
             b.bind(TaskManager.class).toInstance(getTaskManager());
+            b.bind(IndexNameExpressionResolver.class).toInstance(indexNameExpressionResolver);
 
             b.bind(SDKClient.class).toInstance(getSdkClient());
             b.bind(SDKClusterService.class).toInstance(getSdkClusterService());

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.extensions.rest.ExtensionRestRequest;
@@ -45,6 +46,8 @@ import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
 import org.opensearch.sdk.handlers.UpdateSettingsRequestHandler;
 import org.opensearch.tasks.TaskManager;
+import org.opensearch.threadpool.ExecutorBuilder;
+import org.opensearch.threadpool.RunnableTaskExecutionListener;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
@@ -65,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -150,6 +154,8 @@ public class ExtensionsRunner {
         new ExtensionsIndicesModuleNameRequestHandler();
     private final ExtensionsRestRequestHandler extensionsRestRequestHandler = new ExtensionsRestRequestHandler(extensionRestPathRegistry);
     private final ExtensionActionRequestHandler extensionsActionRequestHandler;
+    private final AtomicReference<RunnableTaskExecutionListener> runnableTaskListener;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
 
     /**
      * Instantiates a new update settings request handler
@@ -176,7 +182,12 @@ public class ExtensionsRunner {
             .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress())
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort())
             .build();
-        this.threadPool = new ThreadPool(settings);
+
+        final List<ExecutorBuilder<?>> executorBuilders = extension.getExecutorBuilders(settings);
+
+        runnableTaskListener = new AtomicReference<>();
+        this.threadPool = new ThreadPool(settings, runnableTaskListener, executorBuilders.toArray(new ExecutorBuilder[0]));
+        this.indexNameExpressionResolver = new IndexNameExpressionResolver(this.threadPool.getThreadContext());
         this.taskManager = new TaskManager(settings, threadPool, Collections.emptySet());
 
         // save custom settings
@@ -203,6 +214,7 @@ public class ExtensionsRunner {
         modules.add(b -> {
             b.bind(ExtensionsRunner.class).toInstance(this);
             b.bind(Extension.class).toInstance(extension);
+            b.bind(IndexNameExpressionResolver.class).toInstance(indexNameExpressionResolver);
 
             b.bind(SDKNamedXContentRegistry.class).toInstance(getNamedXContentRegistry());
             b.bind(ThreadPool.class).toInstance(getThreadPool());
@@ -371,6 +383,10 @@ public class ExtensionsRunner {
 
     public List<NamedWriteableRegistry.Entry> getCustomNamedWriteables() {
         return this.customNamedWriteables;
+    }
+
+    public IndexNameExpressionResolver getIndexNameExpressionResolver() {
+        return this.indexNameExpressionResolver;
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -227,6 +227,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         assertNotNull(extensionsRunner.getTaskManager());
         assertNotNull(extensionsRunner.getSdkClient());
         assertNotNull(extensionsRunner.getSdkClusterService());
+        assertNotNull(extensionsRunner.getIndexNameExpressionResolver());
 
         settings = extensionsRunner.getSettings();
         assertEquals(ExtensionsRunnerForTest.NODE_NAME, settings.get(ExtensionsRunner.NODE_NAME_SETTING));


### PR DESCRIPTION
### Description
implements the `getExecutorBuilders` extension point within `ExtensionsRunner` and also adds the `indexNameExpressionResolver` to the `extensionRunner` to be used in `createComponents`

The `executorBuilders` extension point will be implemented as part of [start detector](https://github.com/opensearch-project/opensearch-sdk-java/issues/383).

The `indexNameExpressionResolver` will be utilized as part of the [AnomalyResultAction/TransportAction](https://github.com/opensearch-project/opensearch-sdk-java/issues/626)

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
