### PR TITLE
Adding performRequestAsync to SDKRestClient

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -64,6 +64,7 @@ import org.opensearch.client.Requests;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
+import org.opensearch.client.ResponseListener;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.indices.CreateIndexRequest;
@@ -484,6 +485,27 @@ public class SDKClient implements Closeable {
          */
         public Response performRequest(Request request) throws IOException {
             return restHighLevelClient.getLowLevelClient().performRequest(request);
+        }
+
+        /**
+         * Sends a request to the OpenSearch cluster that the client points to.
+         * The request is executed asynchronously and the provided
+         * {@link ResponseListener} gets notified upon request completion or
+         * failure. Selects a host out of the provided ones in a round-robin
+         * fashion. Failing hosts are marked dead and retried after a certain
+         * amount of time (minimum 1 minute, maximum 30 minutes), depending on how
+         * many times they previously failed (the more failures, the later they
+         * will be retried). In case of failures all of the alive nodes (or dead
+         * nodes that deserve a retry) are retried until one responds or none of
+         * them does, in which case an {@link IOException} will be thrown.
+         *
+         * @param request the request to perform
+         * @param responseListener the {@link ResponseListener} to notify when the
+         *      request is completed or fails
+         * @return Cancellable instance that may be used to cancel the request
+         */
+        public Cancellable performRequestAsync(Request request, ResponseListener responseListener) {
+            return restHighLevelClient.getLowLevelClient().performRequestAsync(request, responseListener);
         }
 
         @Override

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -23,6 +23,8 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Cancellable;
 import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseListener;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.PutMappingRequest;
@@ -98,6 +100,15 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertDoesNotThrow(() -> restClient.delete(new DeleteRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.search(new SearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.multiSearch(new MultiSearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertDoesNotThrow(() -> restClient.performRequestAsync(new Request("", ""), new ResponseListener() {
+
+            @Override
+            public void onSuccess(Response response) {}
+
+            @Override
+            public void onFailure(Exception exception) {}
+
+        }));
         expectThrows(ConnectException.class, () -> restClient.performRequest(new Request("GET", "/")));
 
         sdkClient.doCloseHighLevelClient();

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -100,7 +100,7 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertDoesNotThrow(() -> restClient.delete(new DeleteRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.search(new SearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.multiSearch(new MultiSearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
-        assertDoesNotThrow(() -> restClient.performRequestAsync(new Request("", ""), new ResponseListener() {
+        assertDoesNotThrow(() -> restClient.performRequestAsync(new Request("GET", "/"), new ResponseListener() {
 
             @Override
             public void onSuccess(Response response) {}


### PR DESCRIPTION
### Description
Adds the `performRequestAsync` method to SDKRestClient. This allows us to send non-blocking rest requests.

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk-java/issues/644

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
