### PR TITLE
Match Rest Path registry with RestController using SDKMethodHandlers

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -46,6 +46,7 @@ import org.opensearch.sdk.handlers.ExtensionsIndicesModuleRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
 import org.opensearch.sdk.handlers.UpdateSettingsRequestHandler;
+import org.opensearch.sdk.rest.ExtensionRestPathRegistry;
 import org.opensearch.tasks.TaskManager;
 import org.opensearch.threadpool.ExecutorBuilder;
 import org.opensearch.threadpool.RunnableTaskExecutionListener;

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsRestRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsRestRequestHandler.java
@@ -18,10 +18,9 @@ import org.opensearch.extensions.rest.RestExecuteOnExtensionResponse;
 import org.opensearch.sdk.ExtensionRestHandler;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKNamedXContentRegistry;
+import org.opensearch.sdk.rest.ExtensionRestPathRegistry;
 import org.opensearch.sdk.rest.SDKHttpRequest;
 import org.opensearch.sdk.rest.SDKRestRequest;
-
-import org.opensearch.sdk.ExtensionRestPathRegistry;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;

--- a/src/main/java/org/opensearch/sdk/rest/SDKMethodHandlers.java
+++ b/src/main/java/org/opensearch/sdk/rest/SDKMethodHandlers.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sdk.rest;
+
+import org.opensearch.common.Nullable;
+import org.opensearch.sdk.ExtensionRestHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.opensearch.rest.RestRequest.Method;
+
+/**
+ * Encapsulate multiple handlers for the same path, allowing different handlers for different HTTP verbs.
+ * <p>
+ * Used in SDK to provide identical path-matching functionality as OpenSearch, with Extension-based classes.
+ */
+final class SDKMethodHandlers {
+
+    private final String path;
+    private final Map<Method, ExtensionRestHandler> methodHandlers;
+
+    SDKMethodHandlers(String path, ExtensionRestHandler handler, Method... methods) {
+        this.path = path;
+        this.methodHandlers = new HashMap<>(methods.length);
+        for (Method method : methods) {
+            methodHandlers.put(method, handler);
+        }
+    }
+
+    /**
+     * Add a handler for an additional array of methods. Note that {@code SDKMethodHandlers}
+     * does not allow replacing the handler for an already existing method.
+     */
+    SDKMethodHandlers addMethods(ExtensionRestHandler handler, Method... methods) {
+        for (Method method : methods) {
+            ExtensionRestHandler existing = methodHandlers.putIfAbsent(method, handler);
+            if (existing != null) {
+                throw new IllegalArgumentException("Cannot replace existing handler for [" + path + "] for method: " + method);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Returns the handler for the given method or {@code null} if none exists.
+     */
+    @Nullable
+    ExtensionRestHandler getHandler(Method method) {
+        return methodHandlers.get(method);
+    }
+
+    /**
+     * Return a set of all valid HTTP methods for the particular path
+     */
+    Set<Method> getValidMethods() {
+        return methodHandlers.keySet();
+    }
+}

--- a/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionRestPathRegistry.java
@@ -17,6 +17,7 @@ import org.opensearch.extensions.rest.ExtensionRestResponse;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.sdk.rest.ExtensionRestPathRegistry;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class TestExtensionRestPathRegistry extends OpenSearchTestCase {
@@ -73,10 +74,10 @@ public class TestExtensionRestPathRegistry extends OpenSearchTestCase {
     public void testRegisterConflicts() {
         // Can't register same exact name
         assertThrows(IllegalArgumentException.class, () -> extensionRestPathRegistry.registerHandler(Method.GET, "/foo", fooHandler));
-        // Can't register conflicting named wildcards
+        // Can't register conflicting named wildcards, even if method is different
         assertThrows(
             IllegalArgumentException.class,
-            () -> extensionRestPathRegistry.registerHandler(Method.PUT, "/bar/{none}", barHandler)
+            () -> extensionRestPathRegistry.registerHandler(Method.GET, "/bar/{none}", barHandler)
         );
     }
 

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -56,6 +56,7 @@ import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
+import org.opensearch.sdk.rest.ExtensionRestPathRegistry;
 import org.opensearch.sdk.handlers.AcknowledgedResponseHandler;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.Transport;


### PR DESCRIPTION
### Description

Changes the ExtensionRestPathRegistry to store paths in the trie in exactly the same way as the RestController.  While the previous behavior probably accomplished that goal, this method removes any doubt.

### Issues Resolved

Attempted to address #654 but revealed that the bug was in failure to use replaced routes; that will be addressed in #355.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
