### PR TITLE
Add ClusterStateRequest parameter to cluster state transport request

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.TransportAction;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistry;
@@ -35,7 +34,6 @@ import org.opensearch.index.IndicesModuleRequest;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.sdk.api.ActionExtension;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
-import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionActionRequestHandler;
 import org.opensearch.sdk.action.SDKActionModule;
@@ -551,35 +549,6 @@ public class ExtensionsRunner {
         } catch (Exception e) {
             logger.info("Failed to send " + requestType + " request to OpenSearch", e);
         }
-    }
-
-    /**
-     * Requests the cluster state from OpenSearch.  The result will be handled by a {@link ClusterStateResponseHandler}.
-     *
-     * @param transportService  The TransportService defining the connection to OpenSearch.
-     * @return The cluster state of OpenSearch
-     */
-
-    public ClusterState sendClusterStateRequest(TransportService transportService) {
-        logger.info("Sending Cluster State request to OpenSearch");
-        ClusterStateResponseHandler clusterStateResponseHandler = new ClusterStateResponseHandler();
-        try {
-            transportService.sendRequest(
-                opensearchNode,
-                ExtensionsManager.REQUEST_EXTENSION_CLUSTER_STATE,
-                new ExtensionRequest(ExtensionsManager.RequestType.REQUEST_EXTENSION_CLUSTER_STATE),
-                clusterStateResponseHandler
-            );
-            // Wait on cluster state response
-            clusterStateResponseHandler.awaitResponse();
-        } catch (TimeoutException e) {
-            logger.info("Failed to receive Cluster State response from OpenSearch", e);
-        } catch (Exception e) {
-            logger.info("Failed to send Cluster State request to OpenSearch", e);
-        }
-
-        // At this point, response handler has read in the cluster state
-        return clusterStateResponseHandler.getClusterState();
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.SettingUpgrader;
@@ -52,7 +53,7 @@ public class SDKClusterService {
      */
     public ClusterState state() {
         if (extensionsRunner.isInitialized()) {
-            return extensionsRunner.sendClusterStateRequest(extensionsRunner.getExtensionTransportService());
+            return extensionsRunner.getSdkTransportService().sendClusterStateRequest(new ClusterStateRequest().all());
         }
         throw new IllegalStateException("The Extensions Runner has not been initialized.");
     }

--- a/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ClusterStateResponseHandler.java
@@ -15,18 +15,16 @@ import org.opensearch.action.admin.cluster.state.ClusterStateResponse;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.extensions.ExtensionsManager;
-import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
-import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This class handles the response from OpenSearch to a {@link ExtensionsRunner#sendClusterStateRequest(TransportService)} call.
+ * This class handles the response from OpenSearch to a {@link SDKTransportService#sendClusterStateRequest()} call.
  */
 public class ClusterStateResponseHandler implements TransportResponseHandler<ClusterStateResponse> {
     private static final Logger logger = LogManager.getLogger(ClusterStateResponseHandler.class);

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -52,7 +52,6 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.extensions.UpdateSettingsRequest;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
-import org.opensearch.sdk.handlers.ClusterStateResponseHandler;
 import org.opensearch.sdk.handlers.EnvironmentSettingsResponseHandler;
 import org.opensearch.sdk.handlers.ExtensionsInitRequestHandler;
 import org.opensearch.sdk.handlers.ExtensionsRestRequestHandler;
@@ -175,14 +174,6 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
             AcknowledgedResponse.class,
             extensionsRunner.updateSettingsRequestHandler.handleUpdateSettingsRequest(request).getClass()
         );
-    }
-
-    @Test
-    public void testClusterStateRequest() {
-
-        extensionsRunner.sendClusterStateRequest(transportService);
-
-        verify(transportService, times(1)).sendRequest(any(), anyString(), any(), any(ClusterStateResponseHandler.class));
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -12,6 +12,8 @@ package org.opensearch.sdk;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.action.admin.cluster.state.ClusterStateRequest;
+import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -54,12 +56,15 @@ public class TestSDKClusterService extends OpenSearchTestCase {
 
         // After initialization should be successful
         when(extensionsRunner.isInitialized()).thenReturn(true);
-        sdkClusterService.state();
-        verify(extensionsRunner, times(1)).getExtensionTransportService();
+        SDKTransportService sdkTransportService = mock(SDKTransportService.class);
+        when(extensionsRunner.getSdkTransportService()).thenReturn(sdkTransportService);
 
-        ArgumentCaptor<TransportService> argumentCaptor = ArgumentCaptor.forClass(TransportService.class);
-        verify(extensionsRunner, times(1)).sendClusterStateRequest(argumentCaptor.capture());
-        assertNull(argumentCaptor.getValue());
+        sdkClusterService.state();
+        ArgumentCaptor<ClusterStateRequest> argumentCaptor = ArgumentCaptor.forClass(ClusterStateRequest.class);
+        verify(sdkTransportService, times(1)).sendClusterStateRequest(argumentCaptor.capture());
+        assertArrayEquals(Strings.EMPTY_ARRAY, argumentCaptor.getValue().indices());
+        assertTrue(argumentCaptor.getValue().nodes());
+        assertTrue(argumentCaptor.getValue().routingTable());
     }
 
     @Test


### PR DESCRIPTION
Companion PR on OpenSearch: https://github.com/opensearch-project/OpenSearch/pull/7066

### Description

Adds the ability to send a `ClusterStateRequest` parameter when requesting Cluster State, to limit the values returned (and reduce transport bandwidth).  To get the old behavior, use `new ClusterStateRequest().all()` as the parameter.

### Issues Resolved

Fixes #354 (caveat: we should decide whether to add a call to this method in the SDKClient (which requires passing the TransportService around). For now it is accessible to extensions via `ExtensionsRunner.getSdkTransportService()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
