### PR TITLE
Implement getFieldMapping on SDKRestClient

### DIFF
--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -40,9 +40,9 @@ The `client.execute(action, request, responseListener)` method is implemented on
 
 For TransportActions internal to the plugin (registered with `getActions()`), change the transport action inheritance from HandledTransportAction to directly inherit from `TransportAction`.
 
-TransportActions on OpenSearch are not accessible to extensions, and will need to be replaced with functionality from either a client or some other functionality directly provided by the Extensions SDK.  A few examples of the types of changes needed include:
+TransportActions on OpenSearch are not accessible to extensions, and will need to be replaced with functionality from either a client (OpenSearch Client for Java or the SDKRestClient) or some other functionality directly provided by the Extensions SDK.  A few examples of the types of changes needed include:
  - Some transport actions on OpenSearch, such as the `GetFieldMappingsAction`, are exposed via the REST API and should be called using those clients.
- - Some transport actions on OpenSearch, such as getting Cluster State to test the creation of an index, result in far more data transfer than is needed and should be replaced by REST API calls to endpoints which filter to just the information required. For example, testing for the existence of an index should use one of the Index API endpoints.
+ - Some information available from services on OpenSearch, such as the state on ClusterService, stats on IndexingPressure object, and others, are designed for local access and would transfer far more data than needed if implemented directly. Calls to these services should be replaced by REST API calls to endpoints which filter to just the information required. For example, cluster state associated with inidices should use one of the Index API endpoints. Indexing Pressure can be retrieved by Node API endpoints.
 
 ### Replace RestHandler with ExtensionRestHandler
 

--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -31,12 +31,18 @@ The `SDKClient` provides two (eventually three) client options.
 
 The [Java Client for OpenSearch](https://github.com/opensearch-project/opensearch-java) (`OpenSearchClient`) will be supported with both synchronous and asynchronous clients, and is actively developed along with other language clients and should be used whenever possible. These clients do have significant implementation differences compared to the existing `Client` interface implemented by plugins.
 
+## Change Plugin and OpenSearch TransportAction implementations
+
 The `SDKRestClient` provides wrapper methods matching the `Client` API (but not implementing it), implemented internally with the (soon to be deprecated) `RestHighLevelClient`.  While this speeds migration efforts, it should be considered a temporary "bridge" with follow up migration efforts to the `OpenSearchClient` planned.
  - While the class names and method parameters are the same, the `Request` and `Response` classes are often in different packages. In most cases, other than changing `import` statements, no additional code changes are required. In a few cases, there are minor changes required to interface with the new response class API.
 
 The `client.execute(action, request, responseListener)` method is implemented on the SDKClient.
 
-Change the transport action inheritance from HandledTransportAction to directly inherit from `TransportAction`.
+For TransportActions internal to the plugin (registered with `getActions()`), change the transport action inheritance from HandledTransportAction to directly inherit from `TransportAction`.
+
+TransportActions on OpenSearch are not accessible to extensions, and will need to be replaced with functionality from either a client or some other functionality directly provided by the Extensions SDK.  A few examples of the types of changes needed include:
+ - Some transport actions on OpenSearch, such as the `GetFieldMappingsAction`, are exposed via the REST API and should be called using those clients.
+ - Some transport actions on OpenSearch, such as getting Cluster State to test the creation of an index, result in far more data transfer than is needed and should be replaced by REST API calls to endpoints which filter to just the information required. For example, testing for the existence of an index should use one of the Index API endpoints.
 
 ### Replace RestHandler with ExtensionRestHandler
 

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -632,7 +632,7 @@ public class SDKClient implements Closeable {
             GetFieldMappingsRequest getFieldMappingsRequest,
             ActionListener<GetFieldMappingsResponse> listener
         ) {
-            return this.indicesClient.getFieldMappingAsync(getFieldMappingsRequest, RequestOptions.DEFAULT, listener);
+            return this.indicesClient.getFieldMappingAsync(getFieldMappingsRequest, options, listener);
         }
 
         /**

--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -69,6 +69,8 @@ import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.CreateIndexResponse;
+import org.opensearch.client.indices.GetFieldMappingsRequest;
+import org.opensearch.client.indices.GetFieldMappingsResponse;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.GetMappingsResponse;
 import org.opensearch.client.indices.PutMappingRequest;
@@ -617,6 +619,20 @@ public class SDKClient implements Closeable {
          */
         public Cancellable getMapping(GetMappingsRequest getMappingsRequest, ActionListener<GetMappingsResponse> listener) {
             return this.indicesClient.getMappingAsync(getMappingsRequest, options, listener);
+        }
+
+        /**
+         * Asynchronously retrieves the field mappings on an index or indices using the Get Field Mapping API.
+         *
+         * @param getFieldMappingsRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable getFieldMapping(
+            GetFieldMappingsRequest getFieldMappingsRequest,
+            ActionListener<GetFieldMappingsResponse> listener
+        ) {
+            return this.indicesClient.getFieldMappingAsync(getFieldMappingsRequest, RequestOptions.DEFAULT, listener);
         }
 
         /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -26,6 +26,7 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseListener;
 import org.opensearch.client.indices.CreateIndexRequest;
+import org.opensearch.client.indices.GetFieldMappingsRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.PutMappingRequest;
 import org.opensearch.client.indices.rollover.RolloverRequest;
@@ -124,6 +125,10 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertInstanceOf(Cancellable.class, indicesClient.delete(new DeleteIndexRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(Cancellable.class, indicesClient.putSettings(new UpdateSettingsRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(Cancellable.class, indicesClient.getMapping(new GetMappingsRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertInstanceOf(
+            Cancellable.class,
+            indicesClient.getFieldMapping(new GetFieldMappingsRequest(), ActionListener.wrap(r -> {}, e -> {}))
+        );
         assertInstanceOf(Cancellable.class, indicesClient.putMapping(new PutMappingRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertInstanceOf(
             Cancellable.class,


### PR DESCRIPTION
### Description

Implements the IndicesClient `getFieldMapping()` method on the SDKRestClient.

This provides identical functionality to the Transport Call on AD extension (`GetFieldMappingsAction.INSTANCE`) used for validating the time field, enabling its migration without exposing OpenSearch TransportActions to extensions.

### Issues Resolved

Fixes #361 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
