### PR TITLE
Updates PLUGIN_MIGRATION.md for aggregation return type

### DIFF
--- a/PLUGIN_MIGRATION.md
+++ b/PLUGIN_MIGRATION.md
@@ -69,3 +69,9 @@ Optionally change the `routes()` to `routeHandlers()`.  Change `prepareRequest()
 ### Replace BytesRestResponse with ExtensionRestResponse
 
  - Add the `request` as the first parameter, the remainder of the parameters should be the same.
+
+### Replace Return Type for SDKRestClient
+
+While most SDKRestClient client return types match existing classes, some changes may be necessary to conform to the new method signatures. Examples include:
+- Replace the return type to `ParsedStringTerms` from `StringTerms` to fetch the aggregation for a specific index.
+- Replace `ObjectObjectCursor<String, List<AliasMetadata>> entry` with `Entry<String, Set<AliasMetadata>> entry`


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/anomaly-detection/pull/857#discussion_r1162026254 RestHighLevelClient has the return type of `ParsedStringTerms` while NodeClient used by the plugins has the type as `StringTerms`.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
