### PR TITLE
Fix javadoc links

### DIFF
--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java
@@ -34,7 +34,7 @@ import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.sdk.action.RemoteExtensionActionRequest;
 
 /**
- * This class handles a request from OpenSearch from another extension's {@link SDKTransportService#sendProxyActionRequest()} call.
+ * This class handles a request from OpenSearch from another extension's {@link SDKTransportService#sendRemoteExtensionActionRequest()} call.
  */
 public class ExtensionActionRequestHandler {
     private static final Logger logger = LogManager.getLogger(ExtensionActionRequestHandler.class);

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionActionResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionActionResponseHandler.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This class handles the response from OpenSearch to a {@link SDKTransportService#sendProxyActionRequest()} call.
+ * This class handles the response from OpenSearch to a {@link SDKTransportService#sendRemoteExtensionActionRequest()} call.
  */
 public class ExtensionActionResponseHandler implements TransportResponseHandler<RemoteExtensionActionResponse> {
 

--- a/src/main/java/org/opensearch/sdk/rest/BaseExtensionRestHandler.java
+++ b/src/main/java/org/opensearch/sdk/rest/BaseExtensionRestHandler.java
@@ -273,7 +273,7 @@ public abstract class BaseExtensionRestHandler implements ExtensionRestHandler {
     }
 
     /**
-     * {@code ExtensionDeprecationRestHandler} provides a proxy for any existing {@link Extension RestHandler} so that usage of the handler can be logged using the {@link DeprecationLogger}.
+     * {@code ExtensionDeprecationRestHandler} provides a proxy for any existing {@link ExtensionRestHandler} so that usage of the handler can be logged using the {@link DeprecationLogger}.
      */
     public static class ExtensionDeprecationRestHandler implements ExtensionRestHandler {
 


### PR DESCRIPTION
### Description

Fixes broken build due to javadoc link typos/renames

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
