### PR TITLE
Fix javadocs and improve javadoc CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,19 @@ jobs:
   spotless:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
       - name: Spotless Check
         run: ./gradlew spotlessCheck
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Javadoc CheckStyle
+        run: ./gradlew checkstyleMain
+      - name: Javadoc Check
+        run: ./gradlew javadoc
   check:
-    needs: spotless
+    needs: [spotless, javadoc]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionActionRequestHandler.java
@@ -34,7 +34,7 @@ import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.sdk.action.RemoteExtensionActionRequest;
 
 /**
- * This class handles a request from OpenSearch from another extension's {@link SDKTransportService#sendRemoteExtensionActionRequest()} call.
+ * This class handles a request from OpenSearch from another extension's {@link SDKTransportService#sendRemoteExtensionActionRequest} call.
  */
 public class ExtensionActionRequestHandler {
     private static final Logger logger = LogManager.getLogger(ExtensionActionRequestHandler.class);

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionActionResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionActionResponseHandler.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * This class handles the response from OpenSearch to a {@link SDKTransportService#sendRemoteExtensionActionRequest()} call.
+ * This class handles the response from OpenSearch to a {@link SDKTransportService#sendRemoteExtensionActionRequest} call.
  */
 public class ExtensionActionResponseHandler implements TransportResponseHandler<RemoteExtensionActionResponse> {
 

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsRestRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsRestRequestHandler.java
@@ -41,7 +41,7 @@ public class ExtensionsRestRequestHandler {
      * Instantiate this class with an existing registry
      *
      * @param restPathRegistry The ExtensionsRunnerer's REST path registry
-     * @param sdkNamedXContentRegistry
+     * @param sdkNamedXContentRegistry The SDKNamedXContentRegistry wrapper
      */
     public ExtensionsRestRequestHandler(ExtensionRestPathRegistry restPathRegistry, SDKNamedXContentRegistry sdkNamedXContentRegistry) {
         this.sdkNamedXContentRegistry = sdkNamedXContentRegistry;


### PR DESCRIPTION
### Description

Actually fixes the build, as my previous fix in #696 was incorrect.  You don't need to include params in a linked method but you should leave off the parentheses in that case.

Also updated our CI to fail fast on javadoc checks to prevent these errors from slipping in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
