### PR TITLE
Backport PRs duplicate gradle build and wrapper validation actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Gradle Build
 on:
   push:
     branches-ignore:
+      - 'backport/**'
       - 'whitesource-remediate/**'
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
### Description
#538 

### Issues Resolved
I added the branches-ignore entry for branches starting with backport/ to exclude them from handling the push event.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
