### PR TITLE
Updates delete by query method

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -473,7 +473,7 @@ public class SDKClient implements Closeable {
          * @param listener A listener to be notified with a result
          *
          */
-        public void deleteByQueryAsync(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+        public void deleteByQuery(DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
             restHighLevelClient.deleteByQueryAsync(request, options, listener);
         }
 

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -101,7 +101,7 @@ public class TestSDKClient extends OpenSearchTestCase {
         assertDoesNotThrow(() -> restClient.multiGet(new MultiGetRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.update(new UpdateRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.delete(new DeleteRequest(), ActionListener.wrap(r -> {}, e -> {})));
-        assertDoesNotThrow(() -> restClient.deleteByQueryAsync(new DeleteByQueryRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertDoesNotThrow(() -> restClient.deleteByQuery(new DeleteByQueryRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.search(new SearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.multiSearch(new MultiSearchRequest(), ActionListener.wrap(r -> {}, e -> {})));
         assertDoesNotThrow(() -> restClient.bulk(new BulkRequest(), ActionListener.wrap(r -> {}, e -> {})));


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-sdk-java/pull/708#discussion_r1179889090. 
Updates delete by query method to match with the other methods of SDKClient.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
