### PR TITLE
Update OpenSearch host and port on SDKRestClient after init

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -142,8 +142,16 @@ public class ExtensionSettings {
         return hostPort;
     }
 
+    public void setOpensearchAddress(String opensearchAddress) {
+        this.opensearchAddress = opensearchAddress;
+    }
+
     public String getOpensearchAddress() {
         return opensearchAddress;
+    }
+
+    public void setOpensearchPort(String opensearchPort) {
+        this.opensearchPort = opensearchPort;
     }
 
     public String getOpensearchPort() {

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -62,12 +62,14 @@ public class ExtensionsInitRequestHandler {
             );
         } finally {
             // After sending successful response to initialization, send the REST API and Settings
-            extensionsRunner.setOpensearchNode(extensionsRunner.opensearchNode);
+            extensionsRunner.setOpensearchNode(extensionInitRequest.getSourceNode());
             extensionsRunner.setExtensionNode(extensionInitRequest.getExtension());
+            extensionsRunner.getSdkClient().updateOpenSearchNodeSettings(extensionInitRequest.getSourceNode().getAddress());
+
             // TODO: replace with sdkTransportService.getTransportService()
             TransportService extensionTransportService = extensionsRunner.getExtensionTransportService();
             extensionTransportService.connectToNodeAsExtension(
-                extensionsRunner.opensearchNode,
+                extensionInitRequest.getSourceNode(),
                 extensionInitRequest.getExtension().getId()
             );
             extensionsRunner.sendRegisterRestActionsRequest(extensionTransportService);

--- a/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionSettings.java
@@ -33,6 +33,11 @@ public class TestExtensionSettings extends OpenSearchTestCase {
         assertEquals("4532", extensionSettings.getHostPort());
         assertEquals("127.0.0.1", extensionSettings.getOpensearchAddress());
         assertEquals("9200", extensionSettings.getOpensearchPort());
+
+        extensionSettings.setOpensearchAddress("localhost");
+        assertEquals("localhost", extensionSettings.getOpensearchAddress());
+        extensionSettings.setOpensearchPort("9300");
+        assertEquals("9300", extensionSettings.getOpensearchPort());
     }
 
     @Test

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -9,6 +9,7 @@
 
 package org.opensearch.sdk.sample.helloworld;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hc.core5.http.HttpHost;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,9 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
 import org.opensearch.action.support.TransportAction;
+import org.opensearch.client.Node;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.sdk.api.ActionExtension.ActionHandler;
 import org.opensearch.sdk.rest.ExtensionRestHandler;
 import org.opensearch.sdk.sample.helloworld.transport.SampleAction;
@@ -105,6 +109,22 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
         assertEquals(expected.getExtensionName(), extensionSettings.getExtensionName());
         assertEquals(expected.getHostAddress(), extensionSettings.getHostAddress());
         assertEquals(expected.getHostPort(), extensionSettings.getHostPort());
+    }
+
+    @Test
+    public void testExtensionSettingsUpdate() {
+        List<Node> nodes = this.sdkClient.getSdkRestClient().getRestHighLevelClient().getLowLevelClient().getNodes();
+        assertEquals(1, nodes.size());
+        HttpHost host = nodes.get(0).getHost();
+        assertEquals("localhost", host.getHostName());
+        assertEquals(9200, host.getPort());
+
+        this.sdkClient.updateOpenSearchNodeSettings(new TransportAddress(new InetSocketAddress("10.10.10.10", 9300)));
+        nodes = this.sdkClient.getSdkRestClient().getRestHighLevelClient().getLowLevelClient().getNodes();
+        assertEquals(1, nodes.size());
+        host = nodes.get(0).getHost();
+        assertEquals("10.10.10.10", host.getHostName());
+        assertEquals(9300, host.getPort());
     }
 
     @Test


### PR DESCRIPTION
### Description

Updates the host and port on the RestHighLevelClient following Extension initialization.

This is a combination "quick fix" workaround for the way we've already integrated the deprecated client for migration, plus an update of the client's ExtensionSettings which should work just fine for new instantiations of the Java Clients (which we should not be injecting, see #612).

### Issues Resolved

Fixes #729 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
