### PR TITLE
Adding updateSettings to sdk cluster admin client

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -35,6 +35,8 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -582,6 +584,11 @@ public class SDKClient implements Closeable {
     public static class SDKClusterAdminClient {
 
         private final ClusterClient clusterClient;
+        private RequestOptions options = RequestOptions.DEFAULT;
+
+        public void setOptions(RequestOptions options) {
+            this.options = options;
+        }
 
         /**
          * Instantiate this class using a {@link ClusterClient}.
@@ -592,9 +599,22 @@ public class SDKClient implements Closeable {
             this.clusterClient = clusterClient;
         }
 
+        /**
+         * Asynchronously updates cluster wide specific settings using the Cluster Update Settings API.
+         *
+         * @param clusterUpdateSettingsRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable updateSettings(
+            ClusterUpdateSettingsRequest clusterUpdateSettingsRequest,
+            ActionListener<ClusterUpdateSettingsResponse> listener
+        ) {
+            return clusterClient.putSettingsAsync(clusterUpdateSettingsRequest, options, listener);
+        }
+
         // TODO: Implement state()
         // https://github.com/opensearch-project/opensearch-sdk-java/issues/354
-
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -115,6 +116,19 @@ public class TestSDKClient extends OpenSearchTestCase {
 
         }));
         expectThrows(ConnectException.class, () -> restClient.performRequest(new Request("GET", "/")));
+
+        sdkClient.doCloseHighLevelClient();
+    }
+
+    @Test
+    public void testSDKClusterAdminClient() throws Exception {
+        SDKRestClient restClient = sdkClient.initializeRestClient();
+        SDKClusterAdminClient clusterAdminClient = restClient.cluster();
+
+        assertInstanceOf(
+            Cancellable.class,
+            clusterAdminClient.updateSettings(new ClusterUpdateSettingsRequest(), ActionListener.wrap(r -> {}, e -> {}))
+        );
 
         sdkClient.doCloseHighLevelClient();
     }


### PR DESCRIPTION
### Description
The `ADIntegTestCase` class utilizes the cluster admin client to update transient settings for the integration test cluster [here](https://github.com/opensearch-project/anomaly-detection/blob/c012528b3b95606f0a3683f053b68516161f65fa/src/test/java/org/opensearch/ad/ADIntegTestCase.java#L250). The SDK equivalent [SDKClusterAdminClient](https://github.com/opensearch-project/opensearch-sdk-java/blob/eca424808b3f8a622b4d48d5e34addead301d420/src/main/java/org/opensearch/sdk/SDKClient.java#L582) does not yet have this method available. 

### Issues Resolved
Preparational work for https://github.com/opensearch-project/opensearch-sdk-java/issues/724

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
