### PR TITLE
[Backport 1.x] Replaced implementation() by api() for opensearch libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ import java.nio.file.Files
 import org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework
 
 plugins {
-    id 'java'
+    id 'java-library'
     id "com.diffplug.spotless" version "6.18.0" apply false
     id 'jacoco'
     id "com.form.diff-coverage" version "0.9.5"
@@ -91,13 +91,13 @@ dependencies {
     def junitPlatform = "1.9.3"
     def jaxbVersion = "2.3.1"
 
-    implementation("org.opensearch:opensearch:${opensearchVersion}")
+    api("org.opensearch:opensearch:${opensearchVersion}")
     implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
     implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
     implementation("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
     implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearchVersion}")
-    implementation("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
-    implementation("org.opensearch.client:opensearch-java:${opensearchJavaClientVersion}")
+    api("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
+    api("org.opensearch.client:opensearch-java:${opensearchJavaClientVersion}")
     implementation("org.opensearch.plugin:transport-netty4-client:${opensearchVersion}")
     implementation("io.netty:netty-all:${nettyVersion}")
     testCompileOnly("junit:junit:${junit4Version}") {


### PR DESCRIPTION
Backport 674c627ef8338ed23bef31f5537ee9886a3b8ca8 from #745.

Auto backport failed due to opensearchVersion -> opensearchJavaClientVersion change on 1.x