### PR TITLE
Add default Opensearch host and port if init comes from localhost

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -89,6 +89,14 @@ public class ExtensionsRunner {
      * The key for the extension runner's node name in its settings.
      */
     public static final String NODE_NAME_SETTING = "node.name";
+    /**
+     * OpenSearch default host name.
+     */
+    public static final String OPENSEARCH_HOST_SETTING = "opensearch.host";
+    /**
+     * OpenSearch default host port.
+     */
+    public static final String OPENSEARCH_PORT_SETTING = "opensearch.port";
 
     // The extension being run
     private final Extension extension;
@@ -182,6 +190,8 @@ public class ExtensionsRunner {
         ExtensionSettings extensionSettings = extension.getExtensionSettings();
         Settings.Builder settingsBuilder = Settings.builder()
             .put(NODE_NAME_SETTING, extensionSettings.getExtensionName())
+            .put(OPENSEARCH_HOST_SETTING, extensionSettings.getOpensearchAddress())
+            .put(OPENSEARCH_PORT_SETTING, extensionSettings.getOpensearchPort())
             .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress())
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort());
         boolean sslEnabled = extensionSettings.getSecuritySettings().containsKey(SSL_TRANSPORT_ENABLED)

--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -12,14 +12,22 @@ package org.opensearch.sdk.handlers;
 import org.apache.logging.log4j.LogManager;
 
 import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.discovery.InitializeExtensionRequest;
 import org.opensearch.discovery.InitializeExtensionResponse;
+import org.opensearch.extensions.DiscoveryExtensionNode;
 import org.opensearch.sdk.ExtensionsRunner;
 import org.opensearch.sdk.SDKTransportService;
 import org.opensearch.transport.TransportService;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 import static org.opensearch.sdk.ExtensionsRunner.NODE_NAME_SETTING;
+import static org.opensearch.sdk.ExtensionsRunner.OPENSEARCH_HOST_SETTING;
+import static org.opensearch.sdk.ExtensionsRunner.OPENSEARCH_PORT_SETTING;
 
 /**
  * This class handles the request from OpenSearch to a {@link ExtensionsRunner#startTransportService(TransportService transportService)} call.
@@ -46,14 +54,33 @@ public class ExtensionsInitRequestHandler {
      * @return A response to OpenSearch validating that this is an extension.
      */
     public InitializeExtensionResponse handleExtensionInitRequest(InitializeExtensionRequest extensionInitRequest) {
-        logger.info("Registering Extension Request received from OpenSearch");
-        extensionsRunner.opensearchNode = extensionInitRequest.getSourceNode();
-        extensionsRunner.getThreadPool().getThreadContext().putHeader("extension_unique_id", extensionInitRequest.getExtension().getId());
-        extensionsRunner.setUniqueId(extensionInitRequest.getExtension().getId());
-        // TODO: Remove above two lines in favor of the below when refactoring
+        DiscoveryNode sourceNode = extensionInitRequest.getSourceNode();
+        DiscoveryExtensionNode extensionNode = extensionInitRequest.getExtension();
+        logger.info("Registering Extension Request received from OpenSearch node {}", sourceNode);
+        // In some cases the source node has a localhost IP address which is unreachable from extension.
+        String sourceHost = sourceNode.getAddress().address().getHostString();
+        if ("127.0.0.1".equals(sourceHost)) {
+            // pull from ExtensionSettings instead
+            sourceHost = extensionsRunner.getSettings().get(OPENSEARCH_HOST_SETTING);
+            try {
+                int sourcePort = Integer.valueOf(extensionsRunner.getSettings().get(OPENSEARCH_PORT_SETTING));
+                sourceNode = new DiscoveryNode(
+                    sourceNode.getName(),
+                    new TransportAddress(InetAddress.getByName(sourceHost), sourcePort),
+                    sourceNode.getVersion()
+                );
+            } catch (NumberFormatException | UnknownHostException e) {
+                // If configured defaults don't work, just keep original source node
+            }
+        }
+        extensionsRunner.opensearchNode = sourceNode;
+        extensionsRunner.getThreadPool().getThreadContext().putHeader("extension_unique_id", extensionNode.getId());
+        extensionsRunner.setUniqueId(extensionNode.getId());
+        // TODO: Remove above lines setting extensionRunner node and ID in favor of the below when refactoring
+        // per https://github.com/opensearch-project/opensearch-sdk-java/issues/585
         SDKTransportService sdkTransportService = extensionsRunner.getSdkTransportService();
-        sdkTransportService.setOpensearchNode(extensionInitRequest.getSourceNode());
-        sdkTransportService.setUniqueId(extensionInitRequest.getExtension().getId());
+        sdkTransportService.setOpensearchNode(sourceNode);
+        sdkTransportService.setUniqueId(extensionNode.getId());
         // Successfully initialized. Send the response.
         try {
             return new InitializeExtensionResponse(
@@ -62,7 +89,7 @@ public class ExtensionsInitRequestHandler {
             );
         } finally {
             // After sending successful response to initialization, send the REST API and Settings
-            extensionsRunner.setOpensearchNode(extensionInitRequest.getSourceNode());
+            extensionsRunner.setOpensearchNode(sourceNode);
             extensionsRunner.setExtensionNode(extensionInitRequest.getExtension());
             extensionsRunner.getSdkClient().updateOpenSearchNodeSettings(extensionInitRequest.getSourceNode().getAddress());
 

--- a/src/main/resources/sample/helloworld-settings.yml
+++ b/src/main/resources/sample/helloworld-settings.yml
@@ -1,6 +1,10 @@
+# This name is only used as a response string during init and is purely cosmetic
 extensionName: hello-world
-hostAddress: 127.0.0.1
+# The listening port is bound to the interface with this IP. Set to 0.0.0.0 to listen on all interfaces
+hostAddress: 0.0.0.0
+# The port the Extension listens on
 hostPort: 4532
+# Default opensearch address and port to connect to if the values received during handshake are wrong
 opensearchAddress: 127.0.0.1
 opensearchPort: 9200
 #ssl.transport.enabled: true

--- a/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
+++ b/src/test/java/org/opensearch/sdk/ExtensionsRunnerForTest.java
@@ -26,7 +26,7 @@ public class ExtensionsRunnerForTest extends ExtensionsRunner {
      * @throws IOException if the runner failed to read settings or API.
      */
     public ExtensionsRunnerForTest() throws IOException {
-        super(new BaseExtension(new ExtensionSettings(NODE_NAME, NODE_HOST, NODE_PORT, "127.0.0.1", "9200")) {
+        super(new BaseExtension(new ExtensionSettings(NODE_NAME, NODE_HOST, NODE_PORT, "10.10.10.10", "9200")) {
         });
     }
 

--- a/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
+++ b/src/test/java/org/opensearch/sdk/sample/helloworld/TestHelloWorldExtension.java
@@ -105,7 +105,7 @@ public class TestHelloWorldExtension extends OpenSearchTestCase {
     public void testExtensionSettings() {
         // This effectively tests the Extension interface helper method
         ExtensionSettings extensionSettings = extension.getExtensionSettings();
-        ExtensionSettings expected = new ExtensionSettings("hello-world", "127.0.0.1", "4532", "127.0.0.1", "9200");
+        ExtensionSettings expected = new ExtensionSettings("hello-world", "0.0.0.0", "4532", "127.0.0.1", "9200");
         assertEquals(expected.getExtensionName(), extensionSettings.getExtensionName());
         assertEquals(expected.getHostAddress(), extensionSettings.getHostAddress());
         assertEquals(expected.getHostPort(), extensionSettings.getHostPort());


### PR DESCRIPTION
### Description

Under some circumstances (I believe a single node "cluster") the TransportService identifies its local node at localhost rather than its IP address.  This confuses the ExtensionsInitRequestHandler which has a completely different understanding of localhost, causing it to try to connect to itself on the OpenSearch port.

Since we include an Opensearch host and port in our ExtensionSettings, this uses those as a backup connection string in the event that the information received from OpenSearch is unreliable.

### Issues Resolved

Helps workaround #761 but the problems go deeper than this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
