### PR TITLE
[Extensions] Fixing Imports String.java

### DIFF
--- a/src/main/java/org/opensearch/sdk/api/ActionExtension.java
+++ b/src/main/java/org/opensearch/sdk/api/ActionExtension.java
@@ -18,7 +18,7 @@ import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.TransportAction;
 import org.opensearch.action.support.TransportActions;
-import org.opensearch.common.Strings;
+import org.opensearch.core.common.Strings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.RestHeaderDefinition;
 import org.opensearch.sdk.Extension;

--- a/src/main/java/org/opensearch/sdk/ssl/util/SSLCertificateHelper.java
+++ b/src/main/java/org/opensearch/sdk/ssl/util/SSLCertificateHelper.java
@@ -11,7 +11,7 @@ package org.opensearch.sdk.ssl.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.common.Strings;
+import org.opensearch.core.common.Strings;
 
 import java.security.Key;
 import java.security.KeyStore;


### PR DESCRIPTION
### Description
Fixing String.java imports from OpenSearch. Due to refactoring in OpenSearch now String.java lies on org.opensearch.core.common instead of org.opensearch.common


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
