### PR TITLE
Don't change Extension REST client Settings with transport node info

### DIFF
--- a/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
+++ b/src/main/java/org/opensearch/sdk/handlers/ExtensionsInitRequestHandler.java
@@ -64,7 +64,6 @@ public class ExtensionsInitRequestHandler {
             // After sending successful response to initialization, send the REST API and Settings
             extensionsRunner.setOpensearchNode(extensionInitRequest.getSourceNode());
             extensionsRunner.setExtensionNode(extensionInitRequest.getExtension());
-            extensionsRunner.getSdkClient().updateOpenSearchNodeSettings(extensionInitRequest.getSourceNode().getAddress());
 
             // TODO: replace with sdkTransportService.getTransportService()
             TransportService extensionTransportService = extensionsRunner.getExtensionTransportService();


### PR DESCRIPTION
### Description

Removes the line of code from #730 that updates Extension Settings in the SDK (used for REST connections) based on the OpenSearch node from initialization (used for Transport connections)

### Issues Resolved

Part of ongoing work on #782.  See [comment](https://github.com/opensearch-project/opensearch-sdk-java/issues/782#issuecomment-1563116227).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
