### PR TITLE
Adds exists/aliasExists() methods to SDKIndicesClient

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -77,6 +77,7 @@ import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.CreateIndexResponse;
 import org.opensearch.client.indices.GetFieldMappingsRequest;
 import org.opensearch.client.indices.GetFieldMappingsResponse;
+import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.GetMappingsResponse;
 import org.opensearch.client.indices.PutMappingRequest;
@@ -737,6 +738,28 @@ public class SDKClient implements Closeable {
          */
         public Cancellable getAliases(GetAliasesRequest getAliasesRequest, ActionListener<GetAliasesResponse> listener) {
             return this.indicesClient.getAliasAsync(getAliasesRequest, options, listener);
+        }
+
+        /**
+         * Asynchronously checks if one or more aliases exist using the Aliases Exist API.
+         *
+         * @param getAliasesRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable existsAlias(GetAliasesRequest getAliasesRequest, ActionListener<Boolean> listener) {
+            return this.indicesClient.existsAliasAsync(getAliasesRequest, options, listener);
+        }
+
+        /**
+         * Asynchronously checks if the index (indices) exists or not.
+         *
+         * @param getIndexRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable exists(GetIndexRequest getIndexRequest, ActionListener<Boolean> listener) {
+            return this.indicesClient.existsAsync(getIndexRequest, options, listener);
         }
     }
 }

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -29,6 +29,7 @@ import org.opensearch.client.Response;
 import org.opensearch.client.ResponseListener;
 import org.opensearch.client.indices.CreateIndexRequest;
 import org.opensearch.client.indices.GetFieldMappingsRequest;
+import org.opensearch.client.indices.GetIndexRequest;
 import org.opensearch.client.indices.GetMappingsRequest;
 import org.opensearch.client.indices.PutMappingRequest;
 import org.opensearch.client.indices.rollover.RolloverRequest;
@@ -153,6 +154,8 @@ public class TestSDKClient extends OpenSearchTestCase {
             indicesClient.rolloverIndex(new RolloverRequest("", ""), ActionListener.wrap(r -> {}, e -> {}))
         );
         assertInstanceOf(Cancellable.class, indicesClient.getAliases(new GetAliasesRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertInstanceOf(Cancellable.class, indicesClient.existsAlias(new GetAliasesRequest(), ActionListener.wrap(r -> {}, e -> {})));
+        assertInstanceOf(Cancellable.class, indicesClient.exists(new GetIndexRequest(), ActionListener.wrap(r -> {}, e -> {})));
 
         sdkClient.doCloseHighLevelClient();
     }


### PR DESCRIPTION
### Description
In an effort to replace cluster state calls with more targeted requests, the following methods used to determine if an index exists within a cluster will be replaced by the `SDKIndicesClient` `exists()` and `aliasExists()` methods :

- `state().getRoutingTable().hasIndex(indexName)`
- `state().metadata().hasIndex(indexName)`
- `state().metadata().indices().containsKey(indexName)`
- `state().metadata().hasAlias(alias)`

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/674

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
