### PR TITLE
Added Publish to Maven Local check before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,10 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
+  publish:
+    needs: [check]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Publish to Maven Local
+      run: ./gradlew publishToMavenLocal


### PR DESCRIPTION
### Description
Added task to publish to maven local to detect the failure as a part of PR check.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-sdk-java/issues/801

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
