### PR TITLE
Add changes made in 1.x for manual backport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ repositories {
 
 dependencies {
 
-    def opensearchVersion = "3.0.0-SNAPSHOT"
+    def opensearchVersion = "${opensearch_version}"
     def log4jVersion = "2.20.0"
     def nettyVersion = "4.1.93.Final"
     def jacksonDatabindVersion = "2.15.2"
@@ -184,6 +184,7 @@ dependencies {
         resolutionStrategy.force("org.apache.logging.log4j:log4j-api:${log4jVersion}")
         resolutionStrategy.force("org.apache.logging.log4j:log4j-core:${log4jVersion}")
         resolutionStrategy.force("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
+        resolutionStrategy.force("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
     }
 }
 


### PR DESCRIPTION
### Description
There were a few changes that were required to manually backport https://github.com/opensearch-project/opensearch-sdk-java/pull/687 to 1.x branch.  This PR adds those changes here, so main stays consistent with 1.x.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
