### PR TITLE
Adds health() to SDK Cluster admin client

### DIFF
--- a/src/main/java/org/opensearch/sdk/SDKClient.java
+++ b/src/main/java/org/opensearch/sdk/SDKClient.java
@@ -35,6 +35,8 @@ import org.opensearch.action.ActionListener;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionResponse;
 import org.opensearch.action.ActionType;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
@@ -620,6 +622,18 @@ public class SDKClient implements Closeable {
             ActionListener<ClusterUpdateSettingsResponse> listener
         ) {
             return clusterClient.putSettingsAsync(clusterUpdateSettingsRequest, options, listener);
+        }
+
+        /**
+         * Asynchronously get cluster health using the Cluster Health API.
+         *
+         * If timeout occurred, {@link ClusterHealthResponse} will have isTimedOut() == true and status() == RestStatus.REQUEST_TIMEOUT
+         * @param clusterHealthRequest the request
+         * @param listener the listener to be notified upon request completion
+         * @return cancellable that may be used to cancel the request
+         */
+        public Cancellable health(ClusterHealthRequest clusterHealthRequest, ActionListener<ClusterHealthResponse> listener) {
+            return clusterClient.healthAsync(clusterHealthRequest, options, listener);
         }
 
         // TODO: Implement state()

--- a/src/test/java/org/opensearch/sdk/TestSDKClient.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClient.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 
 import org.junit.jupiter.api.Test;
 import org.opensearch.action.ActionListener;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -130,6 +131,7 @@ public class TestSDKClient extends OpenSearchTestCase {
             Cancellable.class,
             clusterAdminClient.updateSettings(new ClusterUpdateSettingsRequest(), ActionListener.wrap(r -> {}, e -> {}))
         );
+        assertInstanceOf(Cancellable.class, clusterAdminClient.health(new ClusterHealthRequest(), ActionListener.wrap(r -> {}, e -> {})));
 
         sdkClient.doCloseHighLevelClient();
     }


### PR DESCRIPTION
### Description
Companion Anomaly Detector Extension PR : 

Adds health() method to `SDKClusterAdminClient` to retrieve cluster index health status for use in AD Extension

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/674

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
