### PR TITLE
Adds ClusterName to SDKClusterService

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -535,6 +535,7 @@ public class ExtensionsRunner {
      */
     public void updateSdkClusterService() {
         this.sdkClusterService.updateSdkClusterSettings();
+        this.sdkClusterService.updateSdkClusterName();
     }
 
     /**

--- a/src/main/java/org/opensearch/sdk/SDKClusterService.java
+++ b/src/main/java/org/opensearch/sdk/SDKClusterService.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.SettingUpgrader;
@@ -31,6 +32,7 @@ public class SDKClusterService {
 
     private final ExtensionsRunner extensionsRunner;
     private final SDKClusterSettings clusterSettings;
+    private ClusterName clusterName;
 
     /**
      * Create an instance of this object.
@@ -43,6 +45,8 @@ public class SDKClusterService {
         Settings nodeSettings = extensionsRunner.getEnvironmentSettings();
         Set<Setting<?>> settingsSet = new HashSet<>(extensionsRunner.getExtension().getSettings());
         this.clusterSettings = new SDKClusterSettings(nodeSettings, settingsSet);
+        // Set to default on initialization but updated later once connected to OpenSearch
+        this.clusterName = ClusterName.DEFAULT;
     }
 
     /**
@@ -74,8 +78,19 @@ public class SDKClusterService {
         extensionsRunner.getExtension().getSettings().stream().forEach(clusterSettings::registerSetting);
     }
 
+    /**
+     * Updates cluster name with current environment settings value on the extensions runner or default.
+     */
+    public void updateSdkClusterName() {
+        this.clusterName = ClusterName.CLUSTER_NAME_SETTING.get(extensionsRunner.getEnvironmentSettings());
+    }
+
     public SDKClusterSettings getClusterSettings() {
         return clusterSettings;
+    }
+
+    public ClusterName getClusterName() {
+        return clusterName;
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
+++ b/src/test/java/org/opensearch/sdk/TestSDKClusterService.java
@@ -11,6 +11,7 @@ package org.opensearch.sdk;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Setting.Property;
 import org.opensearch.common.settings.Settings;
@@ -69,6 +70,33 @@ public class TestSDKClusterService extends OpenSearchTestCase {
     @Test
     public void testGetClusterSettings() {
         assertInstanceOf(SDKClusterSettings.class, sdkClusterService.getClusterSettings());
+    }
+
+    @Test
+    public void testGetClusterName() {
+        assertInstanceOf(ClusterName.class, sdkClusterService.getClusterName());
+    }
+
+    @Test
+    public void testUpdateSdkClusterName() {
+        String updatedClusterName = "updatedClusterName";
+        ExtensionsRunner mockRunner = mock(ExtensionsRunner.class);
+        Extension mockExtension = mock(Extension.class);
+        Settings updatedSettings = Settings.builder().put("cluster.name", updatedClusterName).build();
+        when(mockRunner.getExtension()).thenReturn(mockExtension);
+        when(mockRunner.getEnvironmentSettings()).thenReturn(Settings.EMPTY) // first invocation during initialization
+            .thenReturn(updatedSettings); // second invocation during update
+        when(mockExtension.getSettings()).thenReturn(Collections.emptyList());
+        SDKClusterService clusterService = new SDKClusterService(mockRunner);
+
+        // Before update
+        ClusterName clusterName = clusterService.getClusterName();
+        assertEquals(ClusterName.DEFAULT, clusterName);
+
+        clusterService.updateSdkClusterName();
+        // After update
+        clusterName = clusterService.getClusterName();
+        assertEquals(updatedClusterName, clusterName.value());
     }
 
     @Test


### PR DESCRIPTION
### Description
Companion Anomaly Detection Extension PR : https://github.com/opensearch-project/anomaly-detection/pull/924

Adds `ClusterName` to `SDKClusterService`, which is initially set to the default value of the ClusterName setting. This is then updated with the cluster name value of the environment settings response after extension intialization

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/674

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
