### PR TITLE
Add javadoc task to enable automatic javadoc publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,11 @@ tasks.named("publishMavenJavaPublicationToMavenLocal").configure { dependsOn("ge
 tasks.named("publishNebulaPublicationToMavenLocal").configure { dependsOn("generatePomFileForMavenJavaPublication") }
 validateMavenJavaPom.enabled = false
 
+javadoc {
+    source = sourceSets.main.allJava
+    classpath = sourceSets.main.compileClasspath
+}
+
 repositories {
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
### Description
This PR adds a javadoc task to `build.gradle`, which Github Actions can pick up and use to automatically publish Javadocs for the repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
