### PR TITLE
fix(bug): Extension should not bind to its hostname

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -159,7 +159,8 @@ public class ExtensionsRunner {
         ExtensionSettings extensionSettings = extension.getExtensionSettings();
         Settings.Builder settingsBuilder = Settings.builder()
             .put(NODE_NAME_SETTING, extensionSettings.getExtensionName())
-            .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress())
+            .put(TransportSettings.PUBLISH_HOST.getKey(), extensionSettings.getHostAddress())
+            .putList(TransportSettings.BIND_HOST.getKey(), Collections.emptyList())
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort());
         boolean sslEnabled = extensionSettings.getSecuritySettings().containsKey(SSL_TRANSPORT_ENABLED)
             && "true".equals(extensionSettings.getSecuritySettings().get(SSL_TRANSPORT_ENABLED));


### PR DESCRIPTION
Closes: #815 

What is the bug?

During initialization, an extension binds to its port on the network interface associated with the host name:

[opensearch-sdk-java/src/main/java/org/opensearch/sdk/ExtensionsRunner.java](https://github.com/opensearch-project/opensearch-sdk-java/blob/5fed5642c9f728d9d67099a0a38cba58a419d968/src/main/java/org/opensearch/sdk/ExtensionsRunner.java#L162)

```
Line 162 in [5fed564](https://github.com/opensearch-project/opensearch-sdk-java/commit/5fed5642c9f728d9d67099a0a38cba58a419d968)
 .put(TransportSettings.BIND_HOST.getKey(), extensionSettings.getHostAddress()) 
```

It is possible for an extension to be listening on multiple interfaces. In particular, the localhost interface will be different than an externally-facing one; it's also possible to have a different interface associated with private and public IP addresses. These may not be known in advance when starting up the extension.
How can one reproduce the bug?

    Start up an extension such as Hello World on a remote node with the default settings (127.0.0.1).
    Attempt to connect to the extension on its configured port.

What is the expected behavior?

Connection established on its listening port.
Do you have any additional context?

On OpenSearch, there are separate settings for BIND_HOST and PUBLISH_HOST. There is no assigned host/IP for BIND_HOST:

    public static final Setting<List<String>> BIND_HOST = listSetting(
        "transport.bind_host",
        HOST,
        Function.identity(),
        Setting.Property.NodeScope
    );

where

    public static final Setting<List<String>> HOST = listSetting(
        "transport.host",
        emptyList(),
        Function.identity(),
        Setting.Property.NodeScope
    );

The extension should probably set BIND_HOST to this same HOST (essentially an empty list), or bind to "0.0.0.0" which listens on all network interfaces. We could/should also set PUBLISH_HOST to the existing value from the settings.
