### PR TITLE
Added release drafter for one click release of SDK

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,45 @@
+name: Release drafter
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-a-release:
+    name: Draft a release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - id: get_data
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+          echo "version=$(./gradlew getVersion  -Dbuild.snapshot=false -Dbuild -q | grep version= | cut -d'=' -f2)" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-sdk-java : ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of opensearch-sdk-java. **VERSION**: ${{ steps.get_data.outputs.version }} **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Build with Gradle
+        run: |
+          ./gradlew --no-daemon -Dbuild.snapshot=false publishNebulaPublicationToLocalRepoRepository && tar -C build -cvf artifacts.tar.gz localRepo
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            artifacts.tar.gz

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ allprojects {
     project.ext.licenseName = 'The Apache Software License, Version 2.0'
     project.ext.licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
     group = 'org.opensearch'
-    version = opensearch_version.tokenize('-')[0] + '.0'
+    version = '2.0.0'
     if (buildVersionQualifier) {
         version += "-${buildVersionQualifier}"
     }
@@ -87,7 +87,6 @@ allprojects {
 
 
 group 'org.opensearch.sdk'
-version '2.0.0-SNAPSHOT'
 
 publishing {
     publications {
@@ -97,13 +96,19 @@ publishing {
     }
 
     repositories {
-        maven {
-            name = "Snapshots" //  optional target repository name
-            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
-            credentials {
-                username "$System.env.SONATYPE_USERNAME"
-                password "$System.env.SONATYPE_PASSWORD"
+        if (version.toString().endsWith("SNAPSHOT")) {
+            maven {
+                name = "Snapshots" //  optional target repository name
+                url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                credentials {
+                    username "$System.env.SONATYPE_USERNAME"
+                    password "$System.env.SONATYPE_PASSWORD"
+                }
             }
+        }
+        maven {
+            name = "localRepo"
+            url = "$buildDir/localRepo"
         }
     }
 }
@@ -199,6 +204,12 @@ task helloWorld(type: JavaExec) {
     description = 'Run HelloWorld Extension.'
     mainClass = 'org.opensearch.sdk.sample.helloworld.HelloWorldExtension'
     classpath = sourceSets.main.runtimeClasspath
+}
+
+task getVersion() {
+    doLast {
+        println("version=${version}")
+    }
 }
 
 test {


### PR DESCRIPTION
### Description
This PR adds a release drafter required for [1-click-release-process](https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#onboarding-to-universal--1-click-release-process). 

- [x] Tested the workflow [here](https://github.com/owaiskazi19/opensearch-sdk-java/actions/runs/5338941475/jobs/9677003118) and published a release on fork [here](https://github.com/owaiskazi19/opensearch-sdk-java/releases/tag/0.1).
- [x] Created a new task in gradle to fetch the version in release-drafter.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-sdk-java/issues/836

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
