### PR TITLE
Bind Extension host to wildcard address

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -160,7 +160,7 @@ public class ExtensionsRunner {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(NODE_NAME_SETTING, extensionSettings.getExtensionName())
             .put(TransportSettings.PUBLISH_HOST.getKey(), extensionSettings.getHostAddress())
-            .putList(TransportSettings.BIND_HOST.getKey(), Collections.emptyList())
+            .put(TransportSettings.BIND_HOST.getKey(), "0.0.0.0")
             .put(TransportSettings.PORT.getKey(), extensionSettings.getHostPort());
         boolean sslEnabled = extensionSettings.getSecuritySettings().containsKey(SSL_TRANSPORT_ENABLED)
             && "true".equals(extensionSettings.getSecuritySettings().get(SSL_TRANSPORT_ENABLED));


### PR DESCRIPTION
### Description

Binds the configured port to listen on any configured network interface.  The attempt to fix this in #830 relied on another OpenSearch configuration to properly work, but doesn't work on its own.

### Issues Resolved

Actually fixes #815

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
