### PR TITLE
Forced slf4j dependency to 1.7.36

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ dependencies {
     def javaxVersion  = "1"
     def guavaFailureAccessVersion = "1.0.1"
     def aopallianceVersion = "1.0"
+    def slf4jVersion = "1.7.36"
 
     api("org.opensearch:opensearch:${opensearchVersion}")
     implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
@@ -194,7 +195,7 @@ dependencies {
         resolutionStrategy.force("org.apache.logging.log4j:log4j-api:${log4jVersion}")
         resolutionStrategy.force("org.apache.logging.log4j:log4j-core:${log4jVersion}")
         resolutionStrategy.force("org.apache.logging.log4j:log4j-jul:${log4jVersion}")
-        resolutionStrategy.force("org.opensearch.client:opensearch-rest-client:${opensearchVersion}")
+        resolutionStrategy.force("org.slf4j:slf4j-api:${slf4jVersion}")
     }
 }
 


### PR DESCRIPTION
### Description
Forced slf4j dependency to 1.7.36 to fix the broken build

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
