### PR TITLE
Update jenkins file to use updated docker image

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -4,6 +4,7 @@ lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v4',
     tokenIdCredential: 'jenkins-opensearch-sdk-java-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/opensearch-sdk-java repository causing this workflow to run',
     downloadReleaseAsset: true,


### PR DESCRIPTION
### Description
We recently upgraded the python version in the build repo. Due to this any code using build repo code fails if right python version is not used. Signing artifacts uses the build repo code hence updating the image to most recent one.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3712

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
