### PR TITLE
Add support for extension_dn

### DIFF
--- a/src/main/java/org/opensearch/sdk/ssl/DefaultSslKeyStore.java
+++ b/src/main/java/org/opensearch/sdk/ssl/DefaultSslKeyStore.java
@@ -17,6 +17,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -457,6 +458,13 @@ public class DefaultSslKeyStore implements SslKeyStore {
         final List<String> newCertDNList = Arrays.stream(newX509Certs).map(formatDNString).sorted().collect(Collectors.toList());
 
         return currentCertDNList.equals(newCertDNList);
+    }
+
+    public boolean hasValidDNs(String dn) {
+        return Arrays.stream(this.transportCerts)
+                .map(X509Certificate::getSubjectX500Principal)
+                .map(Principal::getName)
+                .anyMatch(dn::equals);
     }
 
     /**


### PR DESCRIPTION
### Description
Add support for extension domain name, similar to how it's done for security plugin. More about that in the task: [[Extensions] Add support for extension_dns list in extensions.yml file#2730](https://github.com/opensearch-project/security/issues/2730) 

### Issues Resolved
[[Extensions] Add support for extension_dns list in extensions.yml file#2730](https://github.com/opensearch-project/security/issues/2730)

Currently the implementation looks like this:
1. During extension initialization via REST call, DNs are passed in the request body: 
```
curl -XPOST -k -u user:password "https://localhost:9200/_extensions/initialize" -H "Content-Type:application/json" --data '{ "name":"hello-world", "uniqueId":"hello-world2", "hostAddress":"127.0.0.1", "port":"4500", "version":"1.0", "opensearchVersion":"3.0.0", "minimumCompatibleVersion":"3.0.0", "dependencies":[{"uniqueId":"test1","version":"2.0.0"},{"uniqueId":"test2","version":"3.0.0"}], "extension_dn": "CN=extension-0.example.com,OU=node,O=node,L=test,DC=de" }'
```
2. Request gets parsed and forwarded to extension node, extension_dn get's sent with InitializeExtensionRequest object
3. At this point on the extension side after SSL handshake the DNs get compared, error is thrown if it's incorrect

PR on openserch-core side: 

I'm in the process of writing tests. Main issue I'm facing right now is that I'm wondering if the overall process looks good. Is the validation logic on the right side? Maybe core side should wait for extension response and then accept/reject call?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
