### PR TITLE
Switch to more reliable OpenSearch Lucene snapshot location

### DIFF
--- a/CREATE_YOUR_FIRST_EXTENSION.md
+++ b/CREATE_YOUR_FIRST_EXTENSION.md
@@ -28,7 +28,7 @@ In your dependency management, set up a dependency on the OpenSearch SDK for Jav
 
 At general availability, dependencies will be released to the Central Repository. To use SNAPSHOT versions, add these repositories:
  - OpenSearch SNAPSHOT repository: https://aws.oss.sonatype.org/content/repositories/snapshots/
- - Lucene snapshot repository: https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/
+ - Lucene snapshot repository: https://artifacts.opensearch.org/snapshots/lucene/
 
 If you use Maven, the following POM entries will work:
 
@@ -42,7 +42,7 @@ If you use Maven, the following POM entries will work:
   <repository>
     <id>lucene.snapshots</id>
     <name>Lucene Snapshot Repository</name>
-    <url>https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/</url>
+    <url>https://artifacts.opensearch.org/snapshots/lucene/</url>
   </repository>
 </repositories>
 
@@ -61,7 +61,7 @@ For Gradle, specify dependencies as follows:
 repositories {
   mavenCentral()
   maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots/" }
-  maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/"}
+  maven { url "https://artifacts.opensearch.org/snapshots/lucene/"}
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
-    maven { url "https://d1nvenhzbhpy0q.cloudfront.net/snapshots/lucene/"}
+    maven { url "https://artifacts.opensearch.org/snapshots/lucene/"}
 }
 
 dependencies {


### PR DESCRIPTION
### Description
Switch to more reliable OpenSearch Lucene snapshot location

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-build/issues/3874
- Related https://github.com/opensearch-project/OpenSearch/pull/11728

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
