### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -21,15 +21,15 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew publishMavenJavaPublicationToSnapshotsRepository

--- a/CREATE_YOUR_FIRST_EXTENSION.md
+++ b/CREATE_YOUR_FIRST_EXTENSION.md
@@ -27,7 +27,7 @@ In your dependency management, set up a dependency on the OpenSearch SDK for Jav
  - Version: `1.0.0-SNAPSHOT` (compatible with OpenSearch 2.x) or `2.0.0-SNAPSHOT` (compatible with OpenSearch 3.x)
 
 At general availability, dependencies will be released to the Central Repository. To use SNAPSHOT versions, add these repositories:
- - OpenSearch SNAPSHOT repository: https://aws.oss.sonatype.org/content/repositories/snapshots/
+ - OpenSearch SNAPSHOT repository: https://central.sonatype.com/repository/maven-snapshots/
  - Lucene snapshot repository: https://ci.opensearch.org/ci/dbc/snapshots/lucene/
 
 If you use Maven, the following POM entries will work:
@@ -37,7 +37,7 @@ If you use Maven, the following POM entries will work:
   <repository>
     <id>opensearch.snapshots</id>
     <name>OpenSearch Snapshot Repository</name>
-    <url>https://aws.oss.sonatype.org/content/repositories/snapshots/</url>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
   </repository>
   <repository>
     <id>lucene.snapshots</id>
@@ -60,7 +60,7 @@ For Gradle, specify dependencies as follows:
 ```groovy
 repositories {
   mavenCentral()
-  maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots/" }
+  maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
   maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/"}
 }
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -35,4 +35,4 @@ The release process is standard across repositories in this org and is run by a 
 5. Increment "version" in [build.gradle](https://github.com/opensearch-project/opensearch-sdk-java/blob/main/build.gradle#L79) to the next iteration, e.g. v1.0.1.
 
 ## Snapshot Builds
-The [snapshots builds](https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/sdk/opensearch-sdk-java/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.
+The [snapshots builds](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/org/opensearch/sdk/opensearch-sdk-java/) are published to sonatype using [publish-snapshots.yml](./.github/workflows/publish-snapshots.yml) workflow. Each `push` event to the main branch triggers this workflow.

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     }
 
@@ -130,7 +131,7 @@ publishing {
         if (version.toString().endsWith("SNAPSHOT")) {
             maven {
                 name = "Snapshots" //  optional target repository name
-                url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                url = "https://central.sonatype.com/repository/maven-snapshots/"
                 credentials {
                     username "$System.env.SONATYPE_USERNAME"
                     password "$System.env.SONATYPE_PASSWORD"
@@ -156,6 +157,7 @@ javadoc {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/lucene/"}
 }


### PR DESCRIPTION
### Description
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

### Related Issues
Part of a campaign issue https://github.com/opensearch-project/opensearch-build/issues/5551

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
