### PR TITLE
Upgrade jenkins library version to accomodate new secrets vault

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
+lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
We recently migrated to new one password vault. Upgrading the lib version to accommodate those changes.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
